### PR TITLE
chore: 使用 tiddlynmem 将 TiddlyWiki 笔记导入 Nowledge Mem

### DIFF
--- a/tiddlers/2024-07-12.tid
+++ b/tiddlers/2024-07-12.tid
@@ -1,8 +1,8 @@
 created: 20240712114415846
 creator: TJ
-modified: 20250814150939770
+modified: 20260815033746248
 modifier: TJ
-tags: 
+tags: $:/NowledgeMem
 title: 2024-07-12
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/2025 Frontend 个人思考_1.tid
+++ b/tiddlers/2025 Frontend 个人思考_1.tid
@@ -1,6 +1,6 @@
 created: 20250320045423968
-modified: 20250801090132112
-tags: 
+modified: 20260815033746248
+tags: $:/NowledgeMem
 title: 2025 Frontend 个人思考
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/2025-09-26 突然觉得 JS 框架作者也不是什么很厉害的头衔了.tid
+++ b/tiddlers/2025-09-26 突然觉得 JS 框架作者也不是什么很厉害的头衔了.tid
@@ -1,6 +1,6 @@
 created: 20250926041338372
-modified: 20250926042234324
-tags: 
+modified: 20260815033746248
+tags: $:/NowledgeMem
 title: 2025-09-26 突然觉得 JS 框架作者也不是什么很厉害的头衔了
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/2025-10-03 好像对 React 粉转黑了.tid
+++ b/tiddlers/2025-10-03 好像对 React 粉转黑了.tid
@@ -1,6 +1,6 @@
 created: 20251003015129761
-modified: 20251114070311951
-tags: 
+modified: 20260815033746249
+tags: $:/NowledgeMem
 title: 2025-10-03 好像对 React 粉转黑了
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/2025-10-06 《我目前的 vibe coding 分享》.tid
+++ b/tiddlers/2025-10-06 《我目前的 vibe coding 分享》.tid
@@ -1,6 +1,6 @@
 created: 20251006025205820
-modified: 20251006031613364
-tags: 
+modified: 20260815033746249
+tags: $:/NowledgeMem
 title: 2025-10-06 《我目前的 vibe coding 分享》
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/AI.tid
+++ b/tiddlers/AI.tid
@@ -1,6 +1,6 @@
 created: 20250920072002419
-modified: 20250920072202144
-tags: 
+modified: 20260815033746250
+tags: $:/NowledgeMem
 title: AI
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/AWS SAM Toolkit 无法访问 docker container localhost.tid
+++ b/tiddlers/AWS SAM Toolkit 无法访问 docker container localhost.tid
@@ -1,6 +1,6 @@
 created: 20250712024252222
-modified: 20251211095243120
-tags: #repeated
+modified: 20260815033746251
+tags: #repeated $:/NowledgeMem
 title: AWS SAM Toolkit 无法访问 docker container localhost
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/About.tid
+++ b/tiddlers/About.tid
@@ -1,8 +1,8 @@
 created: 20230221001904248
 creator: TJ
-modified: 20260612035754233
+modified: 20260815033746249
 modifier: TJ
-tags: 
+tags: $:/NowledgeMem
 title: About
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Agents.md.tid
+++ b/tiddlers/Agents.md.tid
@@ -1,6 +1,6 @@
 created: 20250923075625199
-modified: 20250923075928089
-tags: TechRadar/采纳
+modified: 20260815033746249
+tags: TechRadar/采纳 $:/NowledgeMem
 title: Agents.md
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Alpha Beta.tid
+++ b/tiddlers/Alpha Beta.tid
@@ -1,6 +1,6 @@
 created: 20250801061450636
-modified: 20250801061513816
-tags: 
+modified: 20260815033746250
+tags: $:/NowledgeMem
 title: Alpha Beta
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/AppShell.tid
+++ b/tiddlers/AppShell.tid
@@ -1,5 +1,6 @@
 created: 20250829122836547
-modified: 20250829122838059
+modified: 20260815033746250
+tags: $:/NowledgeMem
 title: AppShell
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Ash file upload.tid
+++ b/tiddlers/Ash file upload.tid
@@ -1,6 +1,6 @@
 created: 20251014054206554
-modified: 20251014054325481
-tags: 
+modified: 20260815033746250
+tags: $:/NowledgeMem
 title: Ash file upload
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/AshFramework 将会成为新时代的 rails，powered by elixir.tid
+++ b/tiddlers/AshFramework 将会成为新时代的 rails，powered by elixir.tid
@@ -1,6 +1,6 @@
 created: 20250712080029672
-modified: 20250712080633536
-tags: 
+modified: 20260815033746251
+tags: $:/NowledgeMem
 title: AshFramework 将会成为新时代的 rails，powered by elixir
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/AshFramework.tid
+++ b/tiddlers/AshFramework.tid
@@ -1,6 +1,6 @@
 created: 20250712080527384
-modified: 20250712080603957
-tags: 
+modified: 20260815033746250
+tags: $:/NowledgeMem
 title: AshFramework
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/AshHQ.tid
+++ b/tiddlers/AshHQ.tid
@@ -1,5 +1,6 @@
 created: 20250801045645860
-modified: 20250801045825796
+modified: 20260815033746250
+tags: $:/NowledgeMem
 title: AshHQ
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/AuthZed.tid
+++ b/tiddlers/AuthZed.tid
@@ -1,6 +1,6 @@
 created: 20250926045224505
-modified: 20250926045245369
-tags: TechRadar/语言&框架
+modified: 20260815033746251
+tags: TechRadar/语言&框架 $:/NowledgeMem
 title: AuthZed
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/BEM CSS.tid
+++ b/tiddlers/BEM CSS.tid
@@ -1,6 +1,6 @@
 created: 20250424092128612
-modified: 20250923051105452
-tags: deprecated
+modified: 20260815033746251
+tags: deprecated $:/NowledgeMem
 title: BEM CSS
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Boilerplate Code.tid
+++ b/tiddlers/Boilerplate Code.tid
@@ -1,6 +1,6 @@
 created: 20250923083210250
-modified: 20250923083516679
-tags: 
+modified: 20260815033746251
+tags: $:/NowledgeMem
 title: Boilerplate Code
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Browser-server Model.tid
+++ b/tiddlers/Browser-server Model.tid
@@ -1,6 +1,6 @@
 created: 20250425072117032
-modified: 20250425072250314
-tags: 
+modified: 20260815033746251
+tags: $:/NowledgeMem
 title: Browser-server Model
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/BtoB Marketing Keywords.tid
+++ b/tiddlers/BtoB Marketing Keywords.tid
@@ -1,6 +1,6 @@
 created: 20210620023356815
-modified: 20210620024639909
-tags: 
+modified: 20260815033746251
+tags: $:/NowledgeMem
 title: BtoB Marketing Keywords
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Bun.tid
+++ b/tiddlers/Bun.tid
@@ -1,6 +1,6 @@
 created: 20250514064042706
-modified: 20251211093327966
-tags: tj-stack
+modified: 20260815033746251
+tags: tj-stack $:/NowledgeMem
 title: Bun
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/CRDT.tid
+++ b/tiddlers/CRDT.tid
@@ -1,5 +1,6 @@
 created: 20250320063943126
-modified: 20250424101550357
+modified: 20260815033746253
+tags: $:/NowledgeMem
 title: CRDT
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/CSS Modules.tid
+++ b/tiddlers/CSS Modules.tid
@@ -1,6 +1,6 @@
 created: 20250424064515493
-modified: 20250424103340724
-tags: TechRadar/暂缓
+modified: 20260815033746253
+tags: TechRadar/暂缓 $:/NowledgeMem
 title: CSS Modules
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/CSS rules.tid
+++ b/tiddlers/CSS rules.tid
@@ -1,5 +1,6 @@
 created: 20250424093208344
-modified: 20250424093227940
+modified: 20260815033746254
+tags: $:/NowledgeMem
 title: CSS rules
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/CSS-in-JS.tid
+++ b/tiddlers/CSS-in-JS.tid
@@ -1,6 +1,6 @@
 created: 20250424065436047
-modified: 20250424070052164
-tags: TechRadar/暂缓
+modified: 20260815033746254
+tags: TechRadar/暂缓 $:/NowledgeMem
 title: CSS-in-JS
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/CSS_ flex.tid
+++ b/tiddlers/CSS_ flex.tid
@@ -1,6 +1,6 @@
 created: 20250824183021067
-modified: 20250824183052765
-tags: 
+modified: 20260815033746254
+tags: $:/NowledgeMem
 title: CSS: flex
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Card UI.tid
+++ b/tiddlers/Card UI.tid
@@ -1,6 +1,6 @@
 created: 20250824191347826
-modified: 20250824191419830
-tags: 
+modified: 20260815033746252
+tags: $:/NowledgeMem
 title: Card UI
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/CheerIO.js.tid
+++ b/tiddlers/CheerIO.js.tid
@@ -1,6 +1,6 @@
 created: 20250324131403819
-modified: 20250622032932150
-tags: TechRadar/采纳 TechRadar/语言&框架
+modified: 20260815033746252
+tags: TechRadar/采纳 TechRadar/语言&框架 $:/NowledgeMem
 title: CheerIO.js
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Choices.js.tid
+++ b/tiddlers/Choices.js.tid
@@ -1,6 +1,6 @@
 created: 20250609100524285
-modified: 20250609100704802
-tags: 
+modified: 20260815033746252
+tags: $:/NowledgeMem
 title: Choices.js
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Client handling Server-sent events.tid
+++ b/tiddlers/Client handling Server-sent events.tid
@@ -1,6 +1,6 @@
 created: 20250331071943189
-modified: 20250331074210760
-tags: 
+modified: 20260815033746252
+tags: $:/NowledgeMem
 title: Client handling Server-sent events
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Client–server model.tid
+++ b/tiddlers/Client–server model.tid
@@ -1,6 +1,6 @@
 created: 20250331072616490
-modified: 20250425072037270
-tags: 
+modified: 20260815033746252
+tags: $:/NowledgeMem
 title: Client–server model
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Code Smell.tid
+++ b/tiddlers/Code Smell.tid
@@ -1,6 +1,6 @@
 created: 20250812084238009
-modified: 20250812084257420
-tags: 
+modified: 20260815033746252
+tags: $:/NowledgeMem
 title: Code Smell
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Colima.tid
+++ b/tiddlers/Colima.tid
@@ -1,6 +1,6 @@
 created: 20221107004431023
-modified: 20250923084836781
-tags: TechRadar/放弃
+modified: 20260814152325290
+tags: TechRadar/放弃 $:/NowledgeMem
 title: Colima
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Conform-to_react form.allErrors 和 errors 傻傻分不清楚.tid
+++ b/tiddlers/Conform-to_react form.allErrors 和 errors 傻傻分不清楚.tid
@@ -1,6 +1,6 @@
 created: 20250514100858981
-modified: 20250514101045701
-tags: 
+modified: 20260815033746253
+tags: $:/NowledgeMem
 title: Conform-to/react form.allErrors 和 errors 傻傻分不清楚
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Conform.tid
+++ b/tiddlers/Conform.tid
@@ -1,5 +1,6 @@
 created: 20250514072825571
-modified: 20250514072831520
+modified: 20260815033746253
+tags: $:/NowledgeMem
 title: Conform
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Container queries 是现代 CSS 必须掌握的技能.tid
+++ b/tiddlers/Container queries 是现代 CSS 必须掌握的技能.tid
@@ -1,6 +1,6 @@
 created: 20250919041259012
-modified: 20250919041416140
-tags: 
+modified: 20260815033746253
+tags: $:/NowledgeMem
 title: Container queries 是现代 CSS 必须掌握的技能
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Context7.tid
+++ b/tiddlers/Context7.tid
@@ -1,6 +1,6 @@
 created: 20250806065043637
-modified: 20250807020040233
-tags: TechRadar/工具
+modified: 20260815033746253
+tags: TechRadar/工具 $:/NowledgeMem
 title: Context7
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/DDD domain 常见的错误.tid
+++ b/tiddlers/DDD domain 常见的错误.tid
@@ -1,6 +1,6 @@
 created: 20250605050927114
-modified: 20250801044019578
-tags: 
+modified: 20260815033746255
+tags: $:/NowledgeMem
 title: DDD domain 常见的错误
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Data fetching.tid
+++ b/tiddlers/Data fetching.tid
@@ -1,6 +1,6 @@
 created: 20250318145350151
-modified: 20251008031336270
-tags: 
+modified: 20260815033746254
+tags: $:/NowledgeMem
 title: Data fetching
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Data sync - challenges.tid
+++ b/tiddlers/Data sync - challenges.tid
@@ -1,6 +1,6 @@
 created: 20250320063500088
-modified: 20250320063905247
-tags: 
+modified: 20260815033746254
+tags: $:/NowledgeMem
 title: Data sync - challenges
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Data sync.tid
+++ b/tiddlers/Data sync.tid
@@ -1,6 +1,6 @@
 created: 20250320054020418
-modified: 20250320063449125
-tags: 
+modified: 20260815033746254
+tags: $:/NowledgeMem
 title: Data sync
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Declarative programming.tid
+++ b/tiddlers/Declarative programming.tid
@@ -1,6 +1,6 @@
 created: 20250514092930572
-modified: 20250514093311181
-tags: 
+modified: 20260815033746255
+tags: $:/NowledgeMem
 title: Declarative programming
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/DeepWiki 学习开源项目的好工具.tid
+++ b/tiddlers/DeepWiki 学习开源项目的好工具.tid
@@ -1,6 +1,6 @@
 created: 20250824031954269
-modified: 20251128064429379
-tags: 
+modified: 20260815033746255
+tags: $:/NowledgeMem
 title: DeepWiki 学习开源项目的好工具
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Deploy Micro-Frontends app to Microsoft Azure.tid
+++ b/tiddlers/Deploy Micro-Frontends app to Microsoft Azure.tid
@@ -1,6 +1,6 @@
 created: 20220912113622673
-modified: 20220912115844847
-tags: 
+modified: 20260815033746255
+tags: $:/NowledgeMem
 title: Deploy Micro-Frontends app to Microsoft Azure
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Design System.tid
+++ b/tiddlers/Design System.tid
@@ -1,6 +1,6 @@
 created: 20250625011941844
-modified: 20250625013250001
-tags: 
+modified: 20260815033746255
+tags: $:/NowledgeMem
 title: Design System
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Dexie.js.tid
+++ b/tiddlers/Dexie.js.tid
@@ -1,6 +1,6 @@
 created: 20250920065412458
-modified: 20251008031400556
-tags: TechRadar/放弃
+modified: 20260814152325291
+tags: TechRadar/放弃 $:/NowledgeMem
 title: Dexie.js
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Dify.tid
+++ b/tiddlers/Dify.tid
@@ -1,6 +1,6 @@
 created: 20250326015101730
-modified: 20250326015123960
-tags: 
+modified: 20260815033746255
+tags: $:/NowledgeMem
 title: Dify
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Docker workdir.tid
+++ b/tiddlers/Docker workdir.tid
@@ -1,6 +1,6 @@
 created: 20250520082024036
-modified: 20250520082040820
-tags: 
+modified: 20260815033746256
+tags: $:/NowledgeMem
 title: Docker workdir
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Dockerfile in local 不需要 npm install.tid
+++ b/tiddlers/Dockerfile in local 不需要 npm install.tid
@@ -1,6 +1,6 @@
 created: 20250616051605257
-modified: 20250619061057508
-tags: 
+modified: 20260815033746256
+tags: $:/NowledgeMem
 title: Dockerfile in local 不需要 npm install
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Document.tid
+++ b/tiddlers/Document.tid
@@ -1,6 +1,6 @@
 created: 20251014021354408
-modified: 20251014023446660
-tags: 
+modified: 20260815033746256
+tags: $:/NowledgeMem
 title: Document
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/ElectricSQL.tid
+++ b/tiddlers/ElectricSQL.tid
@@ -1,6 +1,6 @@
 created: 20250318150240028
-modified: 20250926043632821
-tags: [[local first data stack]]
+modified: 20260815033746256
+tags: [[local first data stack]] $:/NowledgeMem
 title: ElectricSQL
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Elixir Keyword List.tid
+++ b/tiddlers/Elixir Keyword List.tid
@@ -1,6 +1,6 @@
 created: 20250824182427031
-modified: 20250824182600083
-tags: 
+modified: 20260815033746256
+tags: $:/NowledgeMem
 title: Elixir Keyword List
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Elixir List_1.tid
+++ b/tiddlers/Elixir List_1.tid
@@ -1,6 +1,6 @@
 created: 20250824182713480
-modified: 20250824182826243
-tags: 
+modified: 20260815033746257
+tags: $:/NowledgeMem
 title: Elixir List
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Elixir Map.tid
+++ b/tiddlers/Elixir Map.tid
@@ -1,6 +1,6 @@
 created: 20250824182119757
-modified: 20250824182301705
-tags: 
+modified: 20260815033746257
+tags: $:/NowledgeMem
 title: Elixir Map
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Elixir Struct.tid
+++ b/tiddlers/Elixir Struct.tid
@@ -1,6 +1,6 @@
 created: 20250824182334108
-modified: 20250824182422193
-tags: 
+modified: 20260815033746257
+tags: $:/NowledgeMem
 title: Elixir Struct
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Elixir Tuple.tid
+++ b/tiddlers/Elixir Tuple.tid
@@ -1,6 +1,6 @@
 created: 20250824182602226
-modified: 20250824182708381
-tags: 
+modified: 20260815033746257
+tags: $:/NowledgeMem
 title: Elixir Tuple
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Elixir 短函数.tid
+++ b/tiddlers/Elixir 短函数.tid
@@ -1,6 +1,6 @@
 created: 20250806041531945
-modified: 20250806043407139
-tags: 
+modified: 20260815033746258
+tags: $:/NowledgeMem
 title: Elixir 短函数
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Elixir 社区.tid
+++ b/tiddlers/Elixir 社区.tid
@@ -1,6 +1,6 @@
 created: 20250425092521925
-modified: 20250425092814967
-tags: 
+modified: 20260815033746257
+tags: $:/NowledgeMem
 title: Elixir 社区
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Frontend Deep Skills.tid
+++ b/tiddlers/Frontend Deep Skills.tid
@@ -1,6 +1,6 @@
 created: 20240712113630442
-modified: 20240712114347527
-tags: 
+modified: 20260815033746258
+tags: $:/NowledgeMem
 title: Frontend Deep Skills
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Full Cycle Developer.tid
+++ b/tiddlers/Full Cycle Developer.tid
@@ -1,6 +1,6 @@
 created: 20250319102009215
-modified: 20250319102157730
-tags: 
+modified: 20260815033746258
+tags: $:/NowledgeMem
 title: Full Cycle Developer
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Future.tid
+++ b/tiddlers/Future.tid
@@ -1,6 +1,6 @@
 created: 20250920071459743
-modified: 20250920073248972
-tags: #Index
+modified: 20260815033746258
+tags: #Index $:/NowledgeMem
 title: Future
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/GenerativeAI.tid
+++ b/tiddlers/GenerativeAI.tid
@@ -1,6 +1,6 @@
 created: 20251013071316420
-modified: 20251014015925260
-tags: 
+modified: 20260815033746258
+tags: $:/NowledgeMem
 title: GenerativeAI
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/GitHub Actions CI=true default.tid
+++ b/tiddlers/GitHub Actions CI=true default.tid
@@ -1,6 +1,6 @@
 created: 20250804054857660
-modified: 20250804054943274
-tags: 
+modified: 20260815033746259
+tags: $:/NowledgeMem
 title: GitHub Actions CI=true default
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/GitHub Actions Tips_ npm install.tid
+++ b/tiddlers/GitHub Actions Tips_ npm install.tid
@@ -1,6 +1,6 @@
 created: 20250514065843488
-modified: 20250730064743426
-tags: 
+modified: 20260815033746259
+tags: $:/NowledgeMem
 title: GitHub Actions Tips: npm install
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/GitHub Actions 先后顺序.tid
+++ b/tiddlers/GitHub Actions 先后顺序.tid
@@ -1,6 +1,6 @@
 created: 20250728092404099
-modified: 20250728100833338
-tags: 
+modified: 20260815033746259
+tags: $:/NowledgeMem
 title: GitHub Actions 先后顺序
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/GitHub Actions 重复利用.tid
+++ b/tiddlers/GitHub Actions 重复利用.tid
@@ -1,6 +1,6 @@
 created: 20250728100841531
-modified: 20250728101042955
-tags: 
+modified: 20260815033746259
+tags: $:/NowledgeMem
 title: GitHub Actions 重复利用
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/GitHub Actions.tid
+++ b/tiddlers/GitHub Actions.tid
@@ -1,6 +1,6 @@
 created: 20250824180245951
-modified: 20250824180414201
-tags: [[What I can do]]
+modified: 20260815033746259
+tags: [[What I can do]] $:/NowledgeMem
 title: GitHub Actions
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/GitHub Merge pull request.tid
+++ b/tiddlers/GitHub Merge pull request.tid
@@ -1,6 +1,6 @@
 created: 20250702082713584
-modified: 20250702083830733
-tags: 
+modified: 20260815033746259
+tags: $:/NowledgeMem
 title: GitHub Merge pull request
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/GitHub actions Cache.tid
+++ b/tiddlers/GitHub actions Cache.tid
@@ -1,6 +1,6 @@
 created: 20250514070403160
-modified: 20250514070956787
-tags: 
+modified: 20260815033746259
+tags: $:/NowledgeMem
 title: GitHub actions Cache
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/GitHub actions Upload files.tid
+++ b/tiddlers/GitHub actions Upload files.tid
@@ -1,6 +1,6 @@
 created: 20250514070305018
-modified: 20250514070349331
-tags: 
+modified: 20260815033746259
+tags: $:/NowledgeMem
 title: GitHub actions Upload files
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/GitHub actions github.sha.tid
+++ b/tiddlers/GitHub actions github.sha.tid
@@ -1,6 +1,6 @@
 created: 20250710073121503
-modified: 20250710073500162
-tags: 
+modified: 20260815033746259
+tags: $:/NowledgeMem
 title: GitHub actions github.sha
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Google Search Console.tid
+++ b/tiddlers/Google Search Console.tid
@@ -1,6 +1,6 @@
 created: 20210603132714227
-modified: 20210603132735586
-tags: 
+modified: 20260815033746259
+tags: $:/NowledgeMem
 title: Google Search Console
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/GraphQL Tips_ 不要使用 .graphql 文件.tid
+++ b/tiddlers/GraphQL Tips_ 不要使用 .graphql 文件.tid
@@ -1,6 +1,6 @@
 created: 20250501024534541
-modified: 20250806025028792
-tags: 
+modified: 20260815033746260
+tags: $:/NowledgeMem
 title: GraphQL Tips: 不要使用 .graphql 文件
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/GraphQL client_ Apollo GraphQL.tid
+++ b/tiddlers/GraphQL client_ Apollo GraphQL.tid
@@ -1,6 +1,6 @@
 created: 20250430031722833
-modified: 20251008030424131
-tags: 
+modified: 20260815033746260
+tags: $:/NowledgeMem
 title: GraphQL client: Apollo GraphQL
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/GraphQL client_ Relay.tid
+++ b/tiddlers/GraphQL client_ Relay.tid
@@ -1,6 +1,6 @@
 created: 20250918052214060
-modified: 20251008031529781
-tags: 2025
+modified: 20260815033746260
+tags: 2025 $:/NowledgeMem
 title: GraphQL client: Relay
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/GraphQL client_ URQL.tid
+++ b/tiddlers/GraphQL client_ URQL.tid
@@ -1,6 +1,6 @@
 created: 20250806023546431
-modified: 20251008031133130
-tags: 
+modified: 20260815033746260
+tags: $:/NowledgeMem
 title: GraphQL client: URQL
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/GraphQL clients.tid
+++ b/tiddlers/GraphQL clients.tid
@@ -1,6 +1,6 @@
 created: 20250430032227049
-modified: 20251008031712984
-tags: 
+modified: 20260815033746260
+tags: $:/NowledgeMem
 title: GraphQL clients
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/HTML dataset.tid
+++ b/tiddlers/HTML dataset.tid
@@ -1,6 +1,6 @@
 created: 20250602011408557
-modified: 20250602012422404
-tags: 
+modified: 20260815033746260
+tags: $:/NowledgeMem
 title: HTML dataset
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/HTML script tag with defer and async.tid
+++ b/tiddlers/HTML script tag with defer and async.tid
@@ -1,8 +1,8 @@
 created: 20240830051902520
 creator: TJ
-modified: 20250312013142739
+modified: 20260815033746260
 modifier: TJ
-tags: Bookmarks
+tags: Bookmarks $:/NowledgeMem
 title: HTML script tag with defer and async
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Hire people.tid
+++ b/tiddlers/Hire people.tid
@@ -1,6 +1,6 @@
 created: 20250902094301350
-modified: 20250902094443352
-tags: 
+modified: 20260815033746260
+tags: $:/NowledgeMem
 title: Hire people
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/IndexedDB.tid
+++ b/tiddlers/IndexedDB.tid
@@ -1,6 +1,6 @@
 created: 20250920070104330
-modified: 20250920070438109
-tags: TechRadar/放弃
+modified: 20260814152325291
+tags: TechRadar/放弃 $:/NowledgeMem
 title: IndexedDB
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Install web app.tid
+++ b/tiddlers/Install web app.tid
@@ -1,6 +1,6 @@
 created: 20250825053936798
-modified: 20250825054430804
-tags: 2025关注
+modified: 20260815033746261
+tags: 2025关注 $:/NowledgeMem
 title: Install web app
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/JS Signals.tid
+++ b/tiddlers/JS Signals.tid
@@ -1,5 +1,6 @@
 created: 20250501015424850
-modified: 20250501015647226
+modified: 20260815033746261
+tags: $:/NowledgeMem
 title: JS Signals
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/JS 不需要使用类似 Java 的面对象.tid
+++ b/tiddlers/JS 不需要使用类似 Java 的面对象.tid
@@ -1,6 +1,6 @@
 created: 20250424093238726
-modified: 20250923050716004
-tags: [[JS Rules]]
+modified: 20260815033746261
+tags: [[JS Rules]] $:/NowledgeMem
 title: JS 不需要使用类似 Java 的面对象
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/JS 字面量对象.tid
+++ b/tiddlers/JS 字面量对象.tid
@@ -1,6 +1,6 @@
 created: 20250507024927603
-modified: 20250507025946977
-tags: 
+modified: 20260815033746261
+tags: $:/NowledgeMem
 title: JS 字面量对象
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/JS 社区.tid
+++ b/tiddlers/JS 社区.tid
@@ -1,6 +1,6 @@
 created: 20250425092012041
-modified: 20250425092512381
-tags: 
+modified: 20260815033746262
+tags: $:/NowledgeMem
 title: JS 社区
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/JS_TS Frameworks.tid
+++ b/tiddlers/JS_TS Frameworks.tid
@@ -1,6 +1,6 @@
 created: 20250622033336313
-modified: 20250622034116339
-tags: 
+modified: 20260815033746262
+tags: $:/NowledgeMem
 title: JS/TS Frameworks
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Langflow.tid
+++ b/tiddlers/Langflow.tid
@@ -1,6 +1,6 @@
 created: 20250326014633372
-modified: 20250326014744882
-tags: 
+modified: 20260815033746262
+tags: $:/NowledgeMem
 title: Langflow
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/LiveStore.tid
+++ b/tiddlers/LiveStore.tid
@@ -1,6 +1,6 @@
 created: 20250825052433351
-modified: 20250825052919028
-tags: [[local first data stack]]
+modified: 20260815033746262
+tags: [[local first data stack]] $:/NowledgeMem
 title: LiveStore
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/LiveView 可以使用 JS commands 调用 server.tid
+++ b/tiddlers/LiveView 可以使用 JS commands 调用 server.tid
@@ -1,6 +1,6 @@
 created: 20250425074853130
-modified: 20250425075128229
-tags: 
+modified: 20260815033746262
+tags: $:/NowledgeMem
 title: LiveView 可以使用 JS commands 调用 server
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/LiveView 的 client-server 通信简单且有效.tid
+++ b/tiddlers/LiveView 的 client-server 通信简单且有效.tid
@@ -1,6 +1,6 @@
 created: 20250425072742777
-modified: 20250425080042409
-tags: 
+modified: 20260815033746262
+tags: $:/NowledgeMem
 title: LiveView 的 client-server 通信简单且有效
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/LiveView.tid
+++ b/tiddlers/LiveView.tid
@@ -1,6 +1,6 @@
 created: 20250501014623239
-modified: 20250501014737538
-tags: 
+modified: 20260815033746262
+tags: $:/NowledgeMem
 title: LiveView
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Local app 必须实现“秒开”.tid
+++ b/tiddlers/Local app 必须实现“秒开”.tid
@@ -1,6 +1,6 @@
 created: 20250812085947324
-modified: 20250825054258454
-tags: 2025关注
+modified: 20260815033746263
+tags: 2025关注 $:/NowledgeMem
 title: Local app 必须实现“秒开”
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/MCP.tid
+++ b/tiddlers/MCP.tid
@@ -1,5 +1,6 @@
 created: 20250326015154739
-modified: 20250326015232707
+modified: 20260815033746263
+tags: $:/NowledgeMem
 title: MCP
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Moondream.ai.tid
+++ b/tiddlers/Moondream.ai.tid
@@ -1,6 +1,6 @@
 created: 20251013050705416
-modified: 20251013052039815
-tags: TechRadar/工具 TechRadar/心动
+modified: 20260815033746263
+tags: TechRadar/工具 TechRadar/心动 $:/NowledgeMem
 title: Moondream.ai
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Moondream.tid
+++ b/tiddlers/Moondream.tid
@@ -1,6 +1,6 @@
 created: 20251211092233524
-modified: 20251211092640569
-tags: [[computer vision tools]]
+modified: 20260815033746263
+tags: [[computer vision tools]] $:/NowledgeMem
 title: Moondream
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/My AI Coding Agents.tid
+++ b/tiddlers/My AI Coding Agents.tid
@@ -1,6 +1,6 @@
 created: 20251128063651596
-modified: 20251128064402382
-tags: 
+modified: 20260815033746264
+tags: $:/NowledgeMem
 title: My AI Coding Agents
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/My CSS.tid
+++ b/tiddlers/My CSS.tid
@@ -1,6 +1,6 @@
 created: 20250905080546814
-modified: 20250905082527146
-tags: 
+modified: 20260815033746263
+tags: $:/NowledgeMem
 title: My CSS
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/MyChanged.tid
+++ b/tiddlers/MyChanged.tid
@@ -1,6 +1,6 @@
 created: 20240805070517644
-modified: 20250923050607820
-tags: 
+modified: 20260815033746264
+tags: $:/NowledgeMem
 title: MyChanged
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Naming Rule.tid
+++ b/tiddlers/Naming Rule.tid
@@ -1,7 +1,7 @@
 created: 20250526021517630
 history: 2025-11-14
-modified: 20251114070606125
-tags: #repeated
+modified: 20260815033746264
+tags: #repeated $:/NowledgeMem
 title: Naming Rule
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Nest.js.tid
+++ b/tiddlers/Nest.js.tid
@@ -1,6 +1,6 @@
 created: 20250622033528504
-modified: 20250923082922711
-tags: TechRadar/放弃
+modified: 20260814152325291
+tags: TechRadar/放弃 $:/NowledgeMem
 title: Nest.js
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/NestJS.tid
+++ b/tiddlers/NestJS.tid
@@ -1,6 +1,6 @@
 created: 20250801051233589
-modified: 20251114065844543
-tags: 
+modified: 20260815033746264
+tags: $:/NowledgeMem
 title: NestJS
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Next.js Function status.tid
+++ b/tiddlers/Next.js Function status.tid
@@ -1,6 +1,6 @@
 created: 20250902095309467
-modified: 20250902095711184
-tags: 
+modified: 20260815033746264
+tags: $:/NowledgeMem
 title: Next.js Function status
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Nitro.tid
+++ b/tiddlers/Nitro.tid
@@ -1,6 +1,6 @@
 created: 20250926041230060
-modified: 20250926041334840
-tags: TechRadar/语言&框架
+modified: 20260815033746264
+tags: TechRadar/语言&框架 $:/NowledgeMem
 title: Nitro
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/No code generation.tid
+++ b/tiddlers/No code generation.tid
@@ -1,6 +1,6 @@
 created: 20250622034443456
-modified: 20250622035054536
-tags: 
+modified: 20260815033746264
+tags: $:/NowledgeMem
 title: No code generation
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Observable.tid
+++ b/tiddlers/Observable.tid
@@ -1,6 +1,6 @@
 created: 20250321013945458
-modified: 20250321014505050
-tags: 
+modified: 20260815033746265
+tags: $:/NowledgeMem
 title: Observable
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/OptimisticUpdates.tid
+++ b/tiddlers/OptimisticUpdates.tid
@@ -1,5 +1,6 @@
 created: 20211214064119836
-modified: 20250801045606632
+modified: 20260815033746265
+tags: $:/NowledgeMem
 title: OptimisticUpdates
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/OrbStack.tid
+++ b/tiddlers/OrbStack.tid
@@ -1,6 +1,6 @@
 created: 20250923084849663
-modified: 20250923084905051
-tags: TechRadar/采纳
+modified: 20260815033746265
+tags: TechRadar/采纳 $:/NowledgeMem
 title: OrbStack
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Powersync.tid
+++ b/tiddlers/Powersync.tid
@@ -1,6 +1,6 @@
 created: 20250825053419642
-modified: 20250825053452593
-tags: [[local first data stack]]
+modified: 20260815033746265
+tags: [[local first data stack]] $:/NowledgeMem
 title: Powersync
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Preact.tid
+++ b/tiddlers/Preact.tid
@@ -1,6 +1,6 @@
 created: 20250425095138096
-modified: 20250425095251328
-tags: 
+modified: 20260815033746265
+tags: $:/NowledgeMem
 title: Preact
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Preview TiddlyWiki 所有 image.tid
+++ b/tiddlers/Preview TiddlyWiki 所有 image.tid
@@ -1,6 +1,6 @@
 created: 20250923023359102
-modified: 20250923045432142
-tags: 
+modified: 20260815033746265
+tags: $:/NowledgeMem
 title: Preview TiddlyWiki 所有 image
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Preview.js.tid
+++ b/tiddlers/Preview.js.tid
@@ -1,6 +1,6 @@
 created: 20250507042938867
-modified: 20250507042948384
-tags: 
+modified: 20260815033746265
+tags: $:/NowledgeMem
 title: Preview.js
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Preview_ $__tags_Image.tid
+++ b/tiddlers/Preview_ $__tags_Image.tid
@@ -1,6 +1,6 @@
 created: 20250923034424157
-modified: 20250923034518337
-tags: 
+modified: 20260815033746266
+tags: $:/NowledgeMem
 title: Preview: $:/tags/Image
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/RAG (Retrieval Augmented Generation).tid
+++ b/tiddlers/RAG (Retrieval Augmented Generation).tid
@@ -1,6 +1,6 @@
 created: 20251014090329430
-modified: 20251014090404819
-tags: 
+modified: 20260815033746266
+tags: $:/NowledgeMem
 title: RAG (Retrieval Augmented Generation)
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/REPL.tid
+++ b/tiddlers/REPL.tid
@@ -1,5 +1,6 @@
 created: 20250622032521915
-modified: 20250622032525707
+modified: 20260815033746268
+tags: $:/NowledgeMem
 title: REPL
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Rails Record scope_1.tid
+++ b/tiddlers/Rails Record scope_1.tid
@@ -1,6 +1,6 @@
 created: 20250604075949500
-modified: 20250604080056894
-tags: 
+modified: 20260815033746266
+tags: $:/NowledgeMem
 title: Rails Record scope
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/React Render Props.tid
+++ b/tiddlers/React Render Props.tid
@@ -1,5 +1,6 @@
 created: 20250425100504364
-modified: 20250425100832389
+modified: 20260815033746267
+tags: $:/NowledgeMem
 title: React Render Props
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/React Router lazy route 可以提高 first page 渲染速度.tid
+++ b/tiddlers/React Router lazy route 可以提高 first page 渲染速度.tid
@@ -1,6 +1,6 @@
 created: 20250824180617972
-modified: 20250824180745714
-tags: [[What I can do]]
+modified: 20260815033746267
+tags: [[What I can do]] $:/NowledgeMem
 title: React Router lazy route 可以提高 first page 渲染速度
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/React Server Components.tid
+++ b/tiddlers/React Server Components.tid
@@ -1,6 +1,6 @@
 created: 20250902092452762
-modified: 20250902093303431
-tags: 
+modified: 20260815033746266
+tags: $:/NowledgeMem
 title: React Server Components
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/React state management.tid
+++ b/tiddlers/React state management.tid
@@ -1,6 +1,6 @@
 created: 20250318142601035
-modified: 20250424101038965
-tags: 
+modified: 20260815033746267
+tags: $:/NowledgeMem
 title: React state management
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/React useDeferredValue().tid
+++ b/tiddlers/React useDeferredValue().tid
@@ -1,6 +1,6 @@
 created: 20250902095105272
-modified: 20250902095123445
-tags: 
+modified: 20260815033746267
+tags: $:/NowledgeMem
 title: React useDeferredValue()
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/React useId().tid
+++ b/tiddlers/React useId().tid
@@ -1,6 +1,6 @@
 created: 20250902094129445
-modified: 20250902094259486
-tags: 
+modified: 20260815033746267
+tags: $:/NowledgeMem
 title: React useId()
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/React 社区声浪最大的 frameworks.tid
+++ b/tiddlers/React 社区声浪最大的 frameworks.tid
@@ -1,6 +1,6 @@
 created: 20250926042452378
-modified: 20250926042700533
-tags: 
+modified: 20260815033746267
+tags: $:/NowledgeMem
 title: React 社区声浪最大的 frameworks
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/React.tid
+++ b/tiddlers/React.tid
@@ -1,6 +1,6 @@
 created: 20250318141618879
-modified: 20250424102130883
-tags: 
+modified: 20260815033746266
+tags: $:/NowledgeMem
 title: React
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/ReactQuery.tid
+++ b/tiddlers/ReactQuery.tid
@@ -1,6 +1,6 @@
 created: 20240807054126064
-modified: 20250424065423944
-tags: TechRadar/暂缓
+modified: 20260815033746268
+tags: TechRadar/暂缓 $:/NowledgeMem
 title: ReactQuery
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Realtime auto-updated UI.tid
+++ b/tiddlers/Realtime auto-updated UI.tid
@@ -1,6 +1,6 @@
 created: 20250920065037433
-modified: 20251114070459856
-tags: #repeated Future
+modified: 20260815033746268
+tags: #repeated Future $:/NowledgeMem
 title: Realtime auto-updated UI
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Redwood.js.tid
+++ b/tiddlers/Redwood.js.tid
@@ -1,6 +1,6 @@
 created: 20250622034120429
-modified: 20250923083207314
-tags: TechRadar/放弃
+modified: 20260814152325291
+tags: TechRadar/放弃 $:/NowledgeMem
 title: Redwood.js
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/RedwoodJS.tid
+++ b/tiddlers/RedwoodJS.tid
@@ -1,6 +1,6 @@
 created: 20251114065726170
-modified: 20251114065811236
-tags: TechRadar/放弃
+modified: 20260814152325292
+tags: TechRadar/放弃 $:/NowledgeMem
 title: RedwoodJS
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Remeda.js pathOr.tid
+++ b/tiddlers/Remeda.js pathOr.tid
@@ -1,6 +1,6 @@
 created: 20250514073551959
-modified: 20250514073635209
-tags: [[point-free style]]
+modified: 20260815033746268
+tags: [[point-free style]] $:/NowledgeMem
 title: Remeda.js pathOr
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Remeda.js toCamelCase.tid
+++ b/tiddlers/Remeda.js toCamelCase.tid
@@ -1,6 +1,6 @@
 created: 20250514073739683
-modified: 20250514073754490
-tags: 
+modified: 20260815033746268
+tags: $:/NowledgeMem
 title: Remeda.js toCamelCase
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Remeda.js 提供 toCamelCase 函数.tid
+++ b/tiddlers/Remeda.js 提供 toCamelCase 函数.tid
@@ -1,6 +1,6 @@
 created: 20250514073955559
-modified: 20250514074353068
-tags: 
+modified: 20260815033746268
+tags: $:/NowledgeMem
 title: Remeda.js 提供 toCamelCase 函数
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Remix.run 的 request flood problem.tid
+++ b/tiddlers/Remix.run 的 request flood problem.tid
@@ -1,6 +1,6 @@
 created: 20250514095437902
-modified: 20250514100821659
-tags: 
+modified: 20260815033746268
+tags: $:/NowledgeMem
 title: Remix.run 的 request flood problem
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Remix.run.tid
+++ b/tiddlers/Remix.run.tid
@@ -1,6 +1,6 @@
 created: 20241111042653834
-modified: 20250622033226685
-tags: TechRadar/语言&框架 TechRadar/放弃
+modified: 20260814152325292
+tags: TechRadar/语言&框架 TechRadar/放弃 $:/NowledgeMem
 title: Remix.run
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/RxDB.tid
+++ b/tiddlers/RxDB.tid
@@ -1,6 +1,6 @@
 created: 20250825045537706
-modified: 20250825051505863
-tags: [[local first data stack]]
+modified: 20260815033746269
+tags: [[local first data stack]] $:/NowledgeMem
 title: RxDB
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/RxJS.tid
+++ b/tiddlers/RxJS.tid
@@ -1,6 +1,6 @@
 created: 20221103020138915
-modified: 20250804060738080
-tags: 
+modified: 20260815033746269
+tags: $:/NowledgeMem
 title: RxJS
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/SASS mixin.tid
+++ b/tiddlers/SASS mixin.tid
@@ -1,6 +1,6 @@
 created: 20250514065403742
-modified: 20250514065607509
-tags: 
+modified: 20260815033746269
+tags: $:/NowledgeMem
 title: SASS mixin
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/SSG (Static Site Generation).tid
+++ b/tiddlers/SSG (Static Site Generation).tid
@@ -1,6 +1,6 @@
 created: 20251014015932716
-modified: 20251014021112011
-tags: TechRadar/放弃
+modified: 20260814152325292
+tags: TechRadar/放弃 $:/NowledgeMem
 title: SSG (Static Site Generation)
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/SSR vs. Embedded Template.tid
+++ b/tiddlers/SSR vs. Embedded Template.tid
@@ -1,6 +1,6 @@
 created: 20250331060537615
-modified: 20250424101404250
-tags: 
+modified: 20260815033746269
+tags: $:/NowledgeMem
 title: SSR vs. Embedded Template
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/SaaS_ GitHub Release workflow.tid
+++ b/tiddlers/SaaS_ GitHub Release workflow.tid
@@ -1,6 +1,6 @@
 created: 20250704080758176
-modified: 20250707014549432
-tags: 
+modified: 20260815033746269
+tags: $:/NowledgeMem
 title: SaaS: GitHub Release workflow
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Sass-lang.tid
+++ b/tiddlers/Sass-lang.tid
@@ -1,6 +1,6 @@
 created: 20250808123001594
-modified: 20250825054615872
-tags: TechRadar/放弃
+modified: 20260814152325292
+tags: TechRadar/放弃 $:/NowledgeMem
 title: Sass-lang
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Server driven UI.tid
+++ b/tiddlers/Server driven UI.tid
@@ -1,5 +1,6 @@
 created: 20221107004431021
-modified: 20250425081037897
+modified: 20260815033746269
+tags: $:/NowledgeMem
 title: Server Driven UI
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Storybook.tid
+++ b/tiddlers/Storybook.tid
@@ -1,6 +1,6 @@
 created: 20250922051938004
-modified: 20250922052230445
-tags: TechRadar/放弃
+modified: 20260814152325292
+tags: TechRadar/放弃 $:/NowledgeMem
 title: Storybook
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/SurrealDB.tid
+++ b/tiddlers/SurrealDB.tid
@@ -1,6 +1,6 @@
 created: 20221108024027565
-modified: 20250801050728273
-tags: 
+modified: 20260815033746270
+tags: $:/NowledgeMem
 title: SurrealDB
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Svelte - 不采用.tid
+++ b/tiddlers/Svelte - 不采用.tid
@@ -1,6 +1,6 @@
 created: 20240805070206094
-modified: 20240809055125902
-tags: 
+modified: 20260815033746270
+tags: $:/NowledgeMem
 title: Svelte - 不采用
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Svelte.tid
+++ b/tiddlers/Svelte.tid
@@ -1,6 +1,6 @@
 created: 20240805070206094
-modified: 20250501015001051
-tags: TechRadar/暂缓
+modified: 20260815033746270
+tags: TechRadar/暂缓 $:/NowledgeMem
 title: Svelte
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Svelte_ the component runs once.tid
+++ b/tiddlers/Svelte_ the component runs once.tid
@@ -1,6 +1,6 @@
 created: 20250425094122683
-modified: 20250425094757220
-tags: 
+modified: 20260815033746270
+tags: $:/NowledgeMem
 title: Svelte: the component runs once
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TJ_ 复杂项目不要使用 static files 部署 frontend.tid
+++ b/tiddlers/TJ_ 复杂项目不要使用 static files 部署 frontend.tid
@@ -1,6 +1,6 @@
 created: 20250711035428526
-modified: 20250711035657315
-tags: 
+modified: 20260815033746273
+tags: $:/NowledgeMem
 title: TJ: 复杂项目不要使用 static files 部署 frontend
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TJ_REC_1.tid
+++ b/tiddlers/TJ_REC_1.tid
@@ -1,5 +1,6 @@
 created: 20250818042450404
-modified: 20250818042612438
+modified: 20260815033746274
+tags: $:/NowledgeMem
 title: TJ_REC
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TJ_must.tid
+++ b/tiddlers/TJ_must.tid
@@ -1,5 +1,6 @@
 created: 20250526022743969
-modified: 20250526022830094
+modified: 20260815033746274
+tags: $:/NowledgeMem
 title: TJ_must
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TanStack Router.tid
+++ b/tiddlers/TanStack Router.tid
@@ -1,6 +1,6 @@
 created: 20221129022740080
-modified: 20241003025025522
-tags: TechRadar/暂缓
+modified: 20260815033746270
+tags: TechRadar/暂缓 $:/NowledgeMem
 title: TanStack Router
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TanStack_1.tid
+++ b/tiddlers/TanStack_1.tid
@@ -1,6 +1,6 @@
 created: 20250923082959459
-modified: 20250926042830265
-tags: TechRadar/暂缓 #Index
+modified: 20260815033746270
+tags: TechRadar/暂缓 #Index $:/NowledgeMem
 title: TanStack
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Tanstack DB.tid
+++ b/tiddlers/Tanstack DB.tid
@@ -1,6 +1,6 @@
 created: 20250825052428181
-modified: 20250926042925263
-tags: 
+modified: 20260815033746270
+tags: $:/NowledgeMem
 title: Tanstack DB
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Tech Interview.tid
+++ b/tiddlers/Tech Interview.tid
@@ -1,6 +1,6 @@
 created: 20250702045729237
-modified: 20250702052632328
-tags: 
+modified: 20260815033746270
+tags: $:/NowledgeMem
 title: Tech Interview
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TechRadar.tid
+++ b/tiddlers/TechRadar.tid
@@ -1,6 +1,6 @@
 created: 20241003023932854
-modified: 20241111042150750
-tags: $:/plugins/adithyab/tiddlyjam/live
+modified: 20260815033746271
+tags: $:/plugins/adithyab/tiddlyjam/live $:/NowledgeMem
 title: TechRadar
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/ThoughtWorks.tid
+++ b/tiddlers/ThoughtWorks.tid
@@ -1,5 +1,6 @@
 created: 20250923084001738
-modified: 20250923084124082
+modified: 20260815033746270
+tags: $:/NowledgeMem
 title: ThoughtWorks
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TiddlyWiki  插入图片.tid
+++ b/tiddlers/TiddlyWiki  插入图片.tid
@@ -1,6 +1,6 @@
 created: 20230217004802664
-modified: 20250804060531447
-tags: 
+modified: 20260815033746271
+tags: $:/NowledgeMem
 title: TiddlyWiki  插入图片
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TiddlyWiki $transaclude Widget.tid
+++ b/tiddlers/TiddlyWiki $transaclude Widget.tid
@@ -1,6 +1,6 @@
 created: 20250502100442976
-modified: 20250502101011618
-tags: 
+modified: 20260815033746271
+tags: $:/NowledgeMem
 title: TiddlyWiki $transaclude Widget
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TiddlyWiki Block Quotes.tid
+++ b/tiddlers/TiddlyWiki Block Quotes.tid
@@ -1,8 +1,8 @@
 created: 20201228103513328
 creator: TJ
-modified: 20250804060531447
+modified: 20260815033746271
 modifier: ThaddeusJiang
-tags: 
+tags: $:/NowledgeMem
 title: TiddlyWiki Block Quotes
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TiddlyWiki Cascades.tid
+++ b/tiddlers/TiddlyWiki Cascades.tid
@@ -1,6 +1,6 @@
 created: 20250502095057030
-modified: 20250502095427177
-tags: 
+modified: 20260815033746271
+tags: $:/NowledgeMem
 title: TiddlyWiki Cascades
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TiddlyWiki Concepts.tid
+++ b/tiddlers/TiddlyWiki Concepts.tid
@@ -1,6 +1,6 @@
 created: 20230228052454234
-modified: 20250804060531447
-tags: 
+modified: 20260815033746271
+tags: $:/NowledgeMem
 title: TiddlyWiki Concepts
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TiddlyWiki Dev.tid
+++ b/tiddlers/TiddlyWiki Dev.tid
@@ -1,6 +1,6 @@
 created: 20250907040203726
-modified: 20250907040955029
-tags: 
+modified: 20260815033746272
+tags: $:/NowledgeMem
 title: TiddlyWiki Dev
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TiddlyWiki Macro Example.tid
+++ b/tiddlers/TiddlyWiki Macro Example.tid
@@ -1,6 +1,6 @@
 created: 20250502101508732
-modified: 20250923045749291
-tags: 
+modified: 20260815033746272
+tags: $:/NowledgeMem
 title: TiddlyWiki Macro Example
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TiddlyWiki Macro 🆚 Widget.tid
+++ b/tiddlers/TiddlyWiki Macro 🆚 Widget.tid
@@ -1,6 +1,6 @@
 created: 20250502101220619
-modified: 20250923045656174
-tags: 
+modified: 20260815033746272
+tags: $:/NowledgeMem
 title: TiddlyWiki Macro 🆚 Widget
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TiddlyWiki Macro.tid
+++ b/tiddlers/TiddlyWiki Macro.tid
@@ -1,6 +1,6 @@
 created: 20230228050151848
-modified: 20250804060531447
-tags: 
+modified: 20260815033746272
+tags: $:/NowledgeMem
 title: TiddlyWiki Macro
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TiddlyWiki Tag 使用.tid
+++ b/tiddlers/TiddlyWiki Tag 使用.tid
@@ -1,6 +1,6 @@
 created: 20250701012740125
-modified: 20250701012946102
-tags: 
+modified: 20260815033746272
+tags: $:/NowledgeMem
 title: TiddlyWiki Tag 使用
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TiddlyWiki Widget.tid
+++ b/tiddlers/TiddlyWiki Widget.tid
@@ -1,6 +1,6 @@
 created: 20230228053253194
-modified: 20250923022740805
-tags: 
+modified: 20260815033746273
+tags: $:/NowledgeMem
 title: TiddlyWiki Widget
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TiddlyWiki delete tiddlers.tid
+++ b/tiddlers/TiddlyWiki delete tiddlers.tid
@@ -1,6 +1,6 @@
 created: 20230228052823943
-modified: 20250804060531447
-tags: 
+modified: 20260815033746271
+tags: $:/NowledgeMem
 title: TiddlyWiki delete tiddlers
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TiddlyWiki list-links.tid
+++ b/tiddlers/TiddlyWiki list-links.tid
@@ -1,8 +1,8 @@
 created: 20201229082355802
 creator: TJ
-modified: 20250804060531447
+modified: 20260815033746272
 modifier: ThaddeusJiang
-tags: 
+tags: $:/NowledgeMem
 title: TiddlyWiki list-links
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TiddlyWiki render Tag UI.tid
+++ b/tiddlers/TiddlyWiki render Tag UI.tid
@@ -1,6 +1,6 @@
 created: 20220601133818754
-modified: 20250804060531447
-tags: 
+modified: 20260815033746272
+tags: $:/NowledgeMem
 title: TiddlyWiki render Tag UI
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TiddlyWiki 使用变量.tid
+++ b/tiddlers/TiddlyWiki 使用变量.tid
@@ -1,8 +1,8 @@
 created: 20230228055835056
 creator: ThaddeusJiang
-modified: 20250804060531447
+modified: 20260815033746273
 modifier: ThaddeusJiang
-tags: 
+tags: $:/NowledgeMem
 title: TiddlyWiki 使用变量
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TiddlyWiki 批量管理 tags.tid
+++ b/tiddlers/TiddlyWiki 批量管理 tags.tid
@@ -1,6 +1,6 @@
 created: 20230228051829728
-modified: 20250804060531447
-tags: 
+modified: 20260815033746273
+tags: $:/NowledgeMem
 title: TiddlyWiki 批量管理 tags
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TiddlyWiki 显示 Tags.tid
+++ b/tiddlers/TiddlyWiki 显示 Tags.tid
@@ -1,6 +1,6 @@
 created: 20250801085542049
-modified: 20250801085649663
-tags: 
+modified: 20260815033746273
+tags: $:/NowledgeMem
 title: TiddlyWiki 显示 Tags
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TiddlyWiki 检查特定 tag 并显示 your-tiddler.tid
+++ b/tiddlers/TiddlyWiki 检查特定 tag 并显示 your-tiddler.tid
@@ -1,6 +1,6 @@
 created: 20250502100129252
-modified: 20250502101700233
-tags: 
+modified: 20260815033746273
+tags: $:/NowledgeMem
 title: TiddlyWiki 检查特定 tag 并显示 your-tiddler
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TiddlyWiki.tid
+++ b/tiddlers/TiddlyWiki.tid
@@ -1,6 +1,6 @@
 created: 20250502092657042
-modified: 20251013052725904
-tags: #Index TechRadar/采纳 MyLove
+modified: 20260815033746271
+tags: #Index TechRadar/采纳 MyLove $:/NowledgeMem
 title: TiddlyWiki
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TidldyWiki 官方使用 macro 自定义 UI Component.tid
+++ b/tiddlers/TidldyWiki 官方使用 macro 自定义 UI Component.tid
@@ -1,6 +1,6 @@
 created: 20250923045835852
-modified: 20250923050323034
-tags: 
+modified: 20260815033746273
+tags: $:/NowledgeMem
 title: TidldyWiki 官方使用 macro 自定义 UI Component
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TinyBase.tid
+++ b/tiddlers/TinyBase.tid
@@ -1,7 +1,7 @@
 created: 20250828033701207
 icon: TinyBase.svg
-modified: 20250920065030171
-tags: [[local first data stack]] TechRadar/工具
+modified: 20260815033746273
+tags: [[local first data stack]] TechRadar/工具 $:/NowledgeMem
 title: TinyBase
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Turso.tid
+++ b/tiddlers/Turso.tid
@@ -1,6 +1,6 @@
 created: 20250825053138402
-modified: 20250825053225669
-tags: [[local first data stack]]
+modified: 20260815033746274
+tags: [[local first data stack]] $:/NowledgeMem
 title: Turso
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TypeScript accepted values 类型安全，例如： sortOrder asc desc.tid
+++ b/tiddlers/TypeScript accepted values 类型安全，例如： sortOrder asc desc.tid
@@ -1,6 +1,6 @@
 created: 20250507035931170
-modified: 20250507041705491
-tags: 
+modified: 20260815033746274
+tags: $:/NowledgeMem
 title: TypeScript accepted values 类型安全，例如： sortOrder asc desc
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TypeScript any vs. unknown.tid
+++ b/tiddlers/TypeScript any vs. unknown.tid
@@ -1,6 +1,6 @@
 created: 20230221000705858
-modified: 20250612063558229
-tags: JS/TS
+modified: 20260815033746274
+tags: JS/TS $:/NowledgeMem
 title: TypeScript any vs. unknown
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TypeScript checklist.tid
+++ b/tiddlers/TypeScript checklist.tid
@@ -1,6 +1,6 @@
 created: 20250808121935723
-modified: 20250808122111565
-tags: 
+modified: 20260815033746274
+tags: $:/NowledgeMem
 title: TypeScript checklist
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TypeScript enum 超酷定义.tid
+++ b/tiddlers/TypeScript enum 超酷定义.tid
@@ -1,6 +1,6 @@
 created: 20250612022229665
-modified: 20250808121906064
-tags: 
+modified: 20260815033746274
+tags: $:/NowledgeMem
 title: TypeScript enum 超酷定义
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/TypeScript enum.tid
+++ b/tiddlers/TypeScript enum.tid
@@ -1,6 +1,6 @@
 created: 20250507040104214
-modified: 20250808121921964
-tags: 
+modified: 20260815033746274
+tags: $:/NowledgeMem
 title: TypeScript enum
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Typesense facet 类似 RDB group_by 功能.tid
+++ b/tiddlers/Typesense facet 类似 RDB group_by 功能.tid
@@ -1,6 +1,6 @@
 created: 20250522063616454
-modified: 20250522063709563
-tags: 
+modified: 20260815033746274
+tags: $:/NowledgeMem
 title: Typesense facet 类似 RDB group_by 功能
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Typesense 不支持 RDB 的 join 操作.tid
+++ b/tiddlers/Typesense 不支持 RDB 的 join 操作.tid
@@ -1,6 +1,6 @@
 created: 20250522063504277
-modified: 20250522063558118
-tags: 
+modified: 20260815033746275
+tags: $:/NowledgeMem
 title: Typesense 不支持 RDB 的 join 操作
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/UI - App Shell.tid
+++ b/tiddlers/UI - App Shell.tid
@@ -1,7 +1,7 @@
 created: 20251209071807370
 history: 2025-12-09
-modified: 20251209071933743
-tags: #repeated
+modified: 20260815033746275
+tags: #repeated $:/NowledgeMem
 title: UI - App Shell
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/UI Hydration.tid
+++ b/tiddlers/UI Hydration.tid
@@ -1,6 +1,6 @@
 created: 20250224031951005
-modified: 20250424101903879
-tags: 
+modified: 20260815033746275
+tags: $:/NowledgeMem
 title: UI Hydration
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/UI Streaming.tid
+++ b/tiddlers/UI Streaming.tid
@@ -1,6 +1,6 @@
 created: 20250224032123234
-modified: 20250424101819614
-tags: 
+modified: 20260815033746275
+tags: $:/NowledgeMem
 title: UI Streaming
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/UI unit test 顶级理解.tid
+++ b/tiddlers/UI unit test 顶级理解.tid
@@ -1,6 +1,6 @@
 created: 20250425091730228
-modified: 20250425092005675
-tags: 
+modified: 20260815033746275
+tags: $:/NowledgeMem
 title: UI unit test 顶级理解
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/UI 秒开.tid
+++ b/tiddlers/UI 秒开.tid
@@ -1,6 +1,6 @@
 created: 20250812090752332
-modified: 20250818042702020
-tags: TJ_技术追求
+modified: 20260815033746275
+tags: TJ_技术追求 $:/NowledgeMem
 title: UI 秒开
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/UI_ app shell.tid
+++ b/tiddlers/UI_ app shell.tid
@@ -1,6 +1,6 @@
 created: 20250829122600312
-modified: 20250829122828710
-tags: 
+modified: 20260815033746275
+tags: $:/NowledgeMem
 title: UI: app shell
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/UI_ state management.tid
+++ b/tiddlers/UI_ state management.tid
@@ -1,6 +1,6 @@
 created: 20250425094822409
-modified: 20250425095528167
-tags: 
+modified: 20260815033746275
+tags: $:/NowledgeMem
 title: UI: state management
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Use Bun.tid
+++ b/tiddlers/Use Bun.tid
@@ -1,6 +1,6 @@
 created: 20250522095005369
-modified: 20251211093315586
-tags: tj-stack
+modified: 20260815033746276
+tags: tj-stack $:/NowledgeMem
 title: Use Bun
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Using Composition to Avoid _Prop Drilling_.tid
+++ b/tiddlers/Using Composition to Avoid _Prop Drilling_.tid
@@ -1,8 +1,8 @@
 created: 20210212031659024
 creator: TJ
-modified: 20250312013338564
+modified: 20260815033746276
 modifier: TJ
-tags: Bookmarks
+tags: Bookmarks $:/NowledgeMem
 title: Using Composition to Avoid "Prop Drilling"
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/VSCode 配置 readonly.tid
+++ b/tiddlers/VSCode 配置 readonly.tid
@@ -1,6 +1,6 @@
 created: 20250514071324324
-modified: 20250514071524986
-tags: 
+modified: 20260815033746277
+tags: $:/NowledgeMem
 title: VSCode 配置 readonly
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Version managers.tid
+++ b/tiddlers/Version managers.tid
@@ -1,6 +1,6 @@
 created: 20251021035134112
-modified: 20251021035203279
-tags: 
+modified: 20260815033746276
+tags: $:/NowledgeMem
 title: Version managers
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Vibe Coding guidelines.tid
+++ b/tiddlers/Vibe Coding guidelines.tid
@@ -1,6 +1,6 @@
 created: 20250923080545997
-modified: 20250925014508949
-tags: 
+modified: 20260815033746276
+tags: $:/NowledgeMem
 title: Vibe Coding guidelines
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/VirtualList.tid
+++ b/tiddlers/VirtualList.tid
@@ -1,6 +1,6 @@
 created: 20240712112044578
-modified: 20250425083252463
-tags: 
+modified: 20260815033746276
+tags: $:/NowledgeMem
 title: VirtualList
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Vitest 测试 Date.tid
+++ b/tiddlers/Vitest 测试 Date.tid
@@ -1,6 +1,6 @@
 created: 20250730042134693
-modified: 20250730042308177
-tags: 
+modified: 20260815033746276
+tags: $:/NowledgeMem
 title: Vitest 测试 Date
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Web Frontend Performance.tid
+++ b/tiddlers/Web Frontend Performance.tid
@@ -1,6 +1,6 @@
 created: 20250925053552906
-modified: 20250925053617570
-tags: 
+modified: 20260815033746277
+tags: $:/NowledgeMem
 title: Web Frontend Performance
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Web Stack in Desktop.tid
+++ b/tiddlers/Web Stack in Desktop.tid
@@ -1,6 +1,6 @@
 created: 20250824033107158
-modified: 20250920070735541
-tags: TechRadar/技术
+modified: 20260815033746277
+tags: TechRadar/技术 $:/NowledgeMem
 title: Web Stack in Desktop
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/WhoDB.tid
+++ b/tiddlers/WhoDB.tid
@@ -1,6 +1,6 @@
 created: 20250925083218355
-modified: 20250925083537398
-tags: TechRadar/工具
+modified: 20260815033746277
+tags: TechRadar/工具 $:/NowledgeMem
 title: WhoDB
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/XR.tid
+++ b/tiddlers/XR.tid
@@ -1,6 +1,6 @@
 created: 20250920071627328
-modified: 20250920071949129
-tags: Future
+modified: 20260815033746277
+tags: Future $:/NowledgeMem
 title: XR
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/YOLO.tid
+++ b/tiddlers/YOLO.tid
@@ -1,6 +1,6 @@
 created: 20251211093001631
-modified: 20251211093045146
-tags: [[computer vision tools]]
+modified: 20260815033746277
+tags: [[computer vision tools]] $:/NowledgeMem
 title: YOLO
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Zeabur.tid
+++ b/tiddlers/Zeabur.tid
@@ -1,6 +1,6 @@
 created: 20241111041425716
-modified: 20241111042052107
-tags: TechRadar/试验 TechRadar/平台
+modified: 20260815033746278
+tags: TechRadar/试验 TechRadar/平台 $:/NowledgeMem
 title: Zeabur
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Zero JS.tid
+++ b/tiddlers/Zero JS.tid
@@ -1,6 +1,6 @@
 created: 20250825051520141
-modified: 20250825052345334
-tags: 
+modified: 20260815033746278
+tags: $:/NowledgeMem
 title: Zero JS
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/Zod .enum.tid
+++ b/tiddlers/Zod .enum.tid
@@ -1,6 +1,6 @@
 created: 20250507041632453
-modified: 20251211094954751
-tags: tj-edu
+modified: 20260815033746278
+tags: tj-edu $:/NowledgeMem
 title: Zod .enum
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/actions_setup-node 自带缓存.tid
+++ b/tiddlers/actions_setup-node 自带缓存.tid
@@ -1,6 +1,6 @@
 created: 20250804060033005
-modified: 20250804060243231
-tags: 
+modified: 20260815033746249
+tags: $:/NowledgeMem
 title: actions/setup-node 自带缓存
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/best dark-mode solution.tid
+++ b/tiddlers/best dark-mode solution.tid
@@ -1,6 +1,6 @@
 created: 20250602095935387
-modified: 20250602101253976
-tags: 
+modified: 20260815033746251
+tags: $:/NowledgeMem
 title: best dark-mode solution
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/better web UI - PPR.tid
+++ b/tiddlers/better web UI - PPR.tid
@@ -1,6 +1,6 @@
 created: 20250801033443910
-modified: 20250801033859395
-tags: 
+modified: 20260815033746252
+tags: $:/NowledgeMem
 title: better web UI - PPR
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/bin_rails 这种管理命令的方式似乎蛮优秀的.tid
+++ b/tiddlers/bin_rails 这种管理命令的方式似乎蛮优秀的.tid
@@ -1,6 +1,6 @@
 created: 20250818060326438
-modified: 20250818060704814
-tags: 
+modified: 20260815033746251
+tags: $:/NowledgeMem
 title: bin/rails 这种管理命令的方式似乎蛮优秀的
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/bun repl.tid
+++ b/tiddlers/bun repl.tid
@@ -1,6 +1,6 @@
 created: 20250514065226832
-modified: 20250514065233906
-tags: 
+modified: 20260815033746252
+tags: $:/NowledgeMem
 title: bun repl
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/class-validator.tid
+++ b/tiddlers/class-validator.tid
@@ -1,6 +1,6 @@
 created: 20250923081957468
-modified: 20250923082017563
-tags: TechRadar/放弃
+modified: 20260814152325291
+tags: TechRadar/放弃 $:/NowledgeMem
 title: class-validator
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/cloc - Count Lines of Code.tid
+++ b/tiddlers/cloc - Count Lines of Code.tid
@@ -1,6 +1,6 @@
 created: 20250514092449699
-modified: 20250514092620973
-tags: 
+modified: 20260815033746252
+tags: $:/NowledgeMem
 title: cloc - Count Lines of Code
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/cloudflare-tunnel.tid
+++ b/tiddlers/cloudflare-tunnel.tid
@@ -1,6 +1,6 @@
 created: 20251203170000000
-modified: 20251203170000000
-tags:
+modified: 20260815033746252
+tags: $:/NowledgeMem
 title: cloudflare-tunnel
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/codegen.tid
+++ b/tiddlers/codegen.tid
@@ -1,6 +1,6 @@
 created: 20250501064907906
-modified: 20250501065142500
-tags: 
+modified: 20260815033746253
+tags: $:/NowledgeMem
 title: codegen
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/coderabbitai.tid
+++ b/tiddlers/coderabbitai.tid
@@ -1,6 +1,6 @@
 created: 20250923065323206
-modified: 20250923065837814
-tags: TechRadar/放弃
+modified: 20260814152325290
+tags: TechRadar/放弃 $:/NowledgeMem
 title: coderabbitai
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/container Tips_ 不要使用通用名称 app, data.tid
+++ b/tiddlers/container Tips_ 不要使用通用名称 app, data.tid
@@ -1,6 +1,6 @@
 created: 20250824181229027
-modified: 20250824181603277
-tags: 
+modified: 20260815033746253
+tags: $:/NowledgeMem
 title: container Tips: 不要使用通用名称 app, data
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/corepack.tid
+++ b/tiddlers/corepack.tid
@@ -1,6 +1,6 @@
 created: 20250514063845479
-modified: 20250923072745743
-tags: TechRadar/采纳
+modified: 20260815033746253
+tags: TechRadar/采纳 $:/NowledgeMem
 title: corepack
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/cursor docs.tid
+++ b/tiddlers/cursor docs.tid
@@ -1,6 +1,6 @@
 created: 20250923081059598
-modified: 20250923081131678
-tags: 
+modified: 20260815033746254
+tags: $:/NowledgeMem
 title: cursor docs
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/daisyUI Card.tid
+++ b/tiddlers/daisyUI Card.tid
@@ -1,6 +1,6 @@
 created: 20250824190832635
-modified: 20250824191327152
-tags: 
+modified: 20260815033746254
+tags: $:/NowledgeMem
 title: daisyUI Card
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/daisyUI.tid
+++ b/tiddlers/daisyUI.tid
@@ -1,6 +1,6 @@
 created: 20250923051107537
-modified: 20250923051706765
-tags: TechRadar/采纳
+modified: 20260815033746254
+tags: TechRadar/采纳 $:/NowledgeMem
 title: daisyUI
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/data sync 细节.tid
+++ b/tiddlers/data sync 细节.tid
@@ -1,6 +1,6 @@
 created: 20251008032052455
-modified: 20251008032558709
-tags: 
+modified: 20260815033746255
+tags: $:/NowledgeMem
 title: data sync 细节
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/direnv.tid
+++ b/tiddlers/direnv.tid
@@ -1,6 +1,6 @@
 created: 20250707014551955
-modified: 20250801080325240
-tags: 
+modified: 20260815033746255
+tags: $:/NowledgeMem
 title: direnv
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/docker compose -f 双开.tid
+++ b/tiddlers/docker compose -f 双开.tid
@@ -1,6 +1,6 @@
 created: 20250808070940781
-modified: 20250808071745481
-tags: 
+modified: 20260815033746255
+tags: $:/NowledgeMem
 title: docker compose -f 双开
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/docker compose volumes _delegated.tid
+++ b/tiddlers/docker compose volumes _delegated.tid
@@ -1,6 +1,6 @@
 created: 20250513091715612
-modified: 20250513092113372
-tags: 
+modified: 20260815033746255
+tags: $:/NowledgeMem
 title: docker compose volumes :delegated
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/docker container hot-reload.tid
+++ b/tiddlers/docker container hot-reload.tid
@@ -1,6 +1,6 @@
 created: 20250513091412816
-modified: 20250513093638671
-tags: 
+modified: 20260815033746256
+tags: $:/NowledgeMem
 title: docker container hot-reload
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/docker desktop 清理资源.tid
+++ b/tiddlers/docker desktop 清理资源.tid
@@ -1,6 +1,6 @@
 created: 20250521051326130
-modified: 20250521051908112
-tags: 
+modified: 20260815033746256
+tags: $:/NowledgeMem
 title: docker desktop 清理资源
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/docker run app --rm.tid
+++ b/tiddlers/docker run app --rm.tid
@@ -1,6 +1,6 @@
 created: 20250731060056507
-modified: 20250731060312943
-tags: 
+modified: 20260815033746256
+tags: $:/NowledgeMem
 title: docker run app --rm
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/elixir ash Optimistic Lock.tid
+++ b/tiddlers/elixir ash Optimistic Lock.tid
@@ -1,6 +1,6 @@
 created: 20250712074646988
-modified: 20250712074934465
-tags: 
+modified: 20260815033746256
+tags: $:/NowledgeMem
 title: elixir ash Optimistic Lock
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/elixir mix MIX_DEPS_PATH.tid
+++ b/tiddlers/elixir mix MIX_DEPS_PATH.tid
@@ -1,6 +1,6 @@
 created: 20260612035255677
-modified: 20260612035713617
-tags: 
+modified: 20260815033746257
+tags: $:/NowledgeMem
 title: elixir mix MIX_DEPS_PATH
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/elixir 生态的 ActiveAdmin.tid
+++ b/tiddlers/elixir 生态的 ActiveAdmin.tid
@@ -1,6 +1,6 @@
 created: 20250712075945207
-modified: 20250712080026680
-tags: 
+modified: 20260815033746257
+tags: $:/NowledgeMem
 title: elixir 生态的 ActiveAdmin
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/enoteca 敏捷开发 失败总结.tid
+++ b/tiddlers/enoteca 敏捷开发 失败总结.tid
@@ -1,6 +1,6 @@
 created: 20210303065613885
-modified: 20211222133942861
-tags: 
+modified: 20260815033746258
+tags: $:/NowledgeMem
 title: enoteca 敏捷开发 失败总结
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/files 就近原则.tid
+++ b/tiddlers/files 就近原则.tid
@@ -1,6 +1,6 @@
 created: 20250605051806482
-modified: 20250801044526061
-tags: 
+modified: 20260815033746258
+tags: $:/NowledgeMem
 title: files 就近原则
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/folder naming.tid
+++ b/tiddlers/folder naming.tid
@@ -1,6 +1,6 @@
 created: 20250708045103670
-modified: 20250708045522397
-tags: 
+modified: 20260815033746258
+tags: $:/NowledgeMem
 title: folder naming
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/frontend Devtools.tid
+++ b/tiddlers/frontend Devtools.tid
@@ -1,6 +1,6 @@
 created: 20251008024348452
-modified: 20251008024657946
-tags: 
+modified: 20260815033746258
+tags: $:/NowledgeMem
 title: frontend Devtools
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/fselect.tid
+++ b/tiddlers/fselect.tid
@@ -1,6 +1,6 @@
 created: 20251203164241000
-modified: 20251203074922378
-tags: tj-stack
+modified: 20260815033746258
+tags: tj-stack $:/NowledgeMem
 title: fselect
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/gRPC.tid
+++ b/tiddlers/gRPC.tid
@@ -1,5 +1,6 @@
 created: 20250324133327607
-modified: 20250324134046430
+modified: 20260815033746260
+tags: $:/NowledgeMem
 title: gRPC
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/git status 中文.tid
+++ b/tiddlers/git status 中文.tid
@@ -1,6 +1,6 @@
 created: 20250514035021856
-modified: 20250806023322868
-tags: 
+modified: 20260815033746258
+tags: $:/NowledgeMem
 title: git status 中文
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/git 查看差分.tid
+++ b/tiddlers/git 查看差分.tid
@@ -1,6 +1,6 @@
 created: 20251114071523914
-modified: 20251114071541516
-tags: 
+modified: 20260815033746258
+tags: $:/NowledgeMem
 title: git 查看差分
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/github.githistory.xyz.tid
+++ b/tiddlers/github.githistory.xyz.tid
@@ -1,5 +1,6 @@
 created: 20250731062647262
-modified: 20250731062732645
+modified: 20260815033746259
+tags: $:/NowledgeMem
 title: github.githistory.xyz
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/graphql apollo-client TypeScript.tid
+++ b/tiddlers/graphql apollo-client TypeScript.tid
@@ -1,6 +1,6 @@
 created: 20250430030602336
-modified: 20251008031004356
-tags: 
+modified: 20260815033746259
+tags: $:/NowledgeMem
 title: graphql apollo-client TypeScript
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/graphql urql TypeScript.tid
+++ b/tiddlers/graphql urql TypeScript.tid
@@ -1,6 +1,6 @@
 created: 20250430030749075
-modified: 20250430032220513
-tags: 
+modified: 20260815033746260
+tags: $:/NowledgeMem
 title: graphql urql TypeScript
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/https___rails-bestpractices.com_.tid
+++ b/tiddlers/https___rails-bestpractices.com_.tid
@@ -1,6 +1,6 @@
 created: 20251209022044539
-modified: 20251209022111285
-tags: 
+modified: 20260815033746260
+tags: $:/NowledgeMem
 title: https://rails-bestpractices.com/
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/immer js.tid
+++ b/tiddlers/immer js.tid
@@ -1,8 +1,8 @@
 created: 20210622082158418
 creator: TJ
-modified: 20250920070647203
+modified: 20260815033746261
 modifier: ThaddeusJiang
-tags: TechRadar/语言&框架 TechRadar/采纳
+tags: TechRadar/语言&框架 TechRadar/采纳 $:/NowledgeMem
 title: immer js
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/inertia.js 用于 classic server-side routing ↔️ SPA 似乎不错.tid
+++ b/tiddlers/inertia.js 用于 classic server-side routing ↔️ SPA 似乎不错.tid
@@ -1,6 +1,6 @@
 created: 20250514085211359
-modified: 20250514090059816
-tags: 
+modified: 20260815033746261
+tags: $:/NowledgeMem
 title: inertia.js 用于 classic server-side routing ↔️ SPA 似乎不错
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/install vs. copy-paste.tid
+++ b/tiddlers/install vs. copy-paste.tid
@@ -1,6 +1,6 @@
 created: 20250430083518646
-modified: 20250430083739637
-tags: 
+modified: 20260815033746261
+tags: $:/NowledgeMem
 title: install vs. copy-paste
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/jotai example.tid
+++ b/tiddlers/jotai example.tid
@@ -1,6 +1,6 @@
 created: 20250424095042671
-modified: 20250424095629071
-tags: 
+modified: 20260815033746261
+tags: $:/NowledgeMem
 title: jotai example
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/jotai.tid
+++ b/tiddlers/jotai.tid
@@ -1,6 +1,6 @@
 created: 20250318145116464
-modified: 20250425095756987
-tags: TechRadar/采纳
+modified: 20260815033746261
+tags: TechRadar/采纳 $:/NowledgeMem
 title: jotai
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/jscpd - js Copy_paste detector.tid
+++ b/tiddlers/jscpd - js Copy_paste detector.tid
@@ -1,6 +1,6 @@
 created: 20250514091832817
-modified: 20251211093352845
-tags: tj-stack
+modified: 20260815033746262
+tags: tj-stack $:/NowledgeMem
 title: jscpd - js Copy/paste detector
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/just.tid
+++ b/tiddlers/just.tid
@@ -1,6 +1,6 @@
 created: 20251126061851740
-modified: 20251126062235380
-tags: 
+modified: 20260815033746262
+tags: $:/NowledgeMem
 title: just
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/k8s pod.tid
+++ b/tiddlers/k8s pod.tid
@@ -1,6 +1,6 @@
 created: 20250514051201144
-modified: 20250514051243943
-tags: 
+modified: 20260815033746262
+tags: $:/NowledgeMem
 title: k8s pod
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/launchd（macOS 原生工具）.tid
+++ b/tiddlers/launchd（macOS 原生工具）.tid
@@ -1,6 +1,6 @@
 created: 20250902114907422
-modified: 20250902115039574
-tags: 
+modified: 20260815033746262
+tags: $:/NowledgeMem
 title: launchd（macOS 原生工具）
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/local first app.tid
+++ b/tiddlers/local first app.tid
@@ -1,6 +1,6 @@
 created: 20250902094543588
-modified: 20250902094809132
-tags: 2025关注
+modified: 20260815033746262
+tags: 2025关注 $:/NowledgeMem
 title: local first app
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/local-fist 文章.tid
+++ b/tiddlers/local-fist 文章.tid
@@ -1,6 +1,6 @@
 created: 20250825052142281
-modified: 20250825052243144
-tags: 
+modified: 20260815033746262
+tags: $:/NowledgeMem
 title: local-fist 文章
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/local_ docker builder prune 清理构建缓存.tid
+++ b/tiddlers/local_ docker builder prune 清理构建缓存.tid
@@ -1,6 +1,6 @@
 created: 20250520031902529
-modified: 20250520032051403
-tags: 
+modified: 20260815033746263
+tags: $:/NowledgeMem
 title: local: docker builder prune 清理构建缓存
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/local_ docker compose 缓解硬盘压力.tid
+++ b/tiddlers/local_ docker compose 缓解硬盘压力.tid
@@ -1,6 +1,6 @@
 created: 20250623014717483
-modified: 20250730025213129
-tags: 
+modified: 20260815033746263
+tags: $:/NowledgeMem
 title: local: docker compose 缓解硬盘压力
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/local_ docker container 和 host 保持内容一致.tid
+++ b/tiddlers/local_ docker container 和 host 保持内容一致.tid
@@ -1,6 +1,6 @@
 created: 20250818073637578
-modified: 20250818075356711
-tags: 
+modified: 20260815033746263
+tags: $:/NowledgeMem
 title: local: docker container 和 host 保持内容一致
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/macOS 打开独立开发者开发的 app.tid
+++ b/tiddlers/macOS 打开独立开发者开发的 app.tid
@@ -1,6 +1,6 @@
 created: 20250808051648276
-modified: 20250808051724648
-tags: 
+modified: 20260815033746263
+tags: $:/NowledgeMem
 title: macOS 打开独立开发者开发的 app
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/macOS 配置存储位置.tid
+++ b/tiddlers/macOS 配置存储位置.tid
@@ -1,6 +1,6 @@
 created: 20251202142419806
-modified: 20251202142545675
-tags: 
+modified: 20260815033746263
+tags: $:/NowledgeMem
 title: macOS 配置存储位置
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/mise.tid
+++ b/tiddlers/mise.tid
@@ -1,6 +1,6 @@
 created: 20251114032021629
-modified: 20251126062126388
-tags: TechRadar/采纳
+modified: 20260815033746263
+tags: TechRadar/采纳 $:/NowledgeMem
 title: mise
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/next.config.ts Partial Prerendering (PPR).tid
+++ b/tiddlers/next.config.ts Partial Prerendering (PPR).tid
@@ -1,6 +1,6 @@
 created: 20250902100334197
-modified: 20250902100411697
-tags: 
+modified: 20260815033746264
+tags: $:/NowledgeMem
 title: next.config.ts Partial Prerendering (PPR)
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/npm publish CSS.tid
+++ b/tiddlers/npm publish CSS.tid
@@ -1,6 +1,6 @@
 created: 20250514034103112
-modified: 20250806023356830
-tags: 
+modified: 20260815033746264
+tags: $:/NowledgeMem
 title: npm publish CSS
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/nuqs.tid
+++ b/tiddlers/nuqs.tid
@@ -1,6 +1,6 @@
 created: 20250318144122306
-modified: 20250622032853304
-tags: TechRadar/采纳
+modified: 20260815033746264
+tags: TechRadar/采纳 $:/NowledgeMem
 title: nuqs
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/ollama.tid
+++ b/tiddlers/ollama.tid
@@ -1,6 +1,6 @@
 created: 20251017013543736
-modified: 20251017013847856
-tags: TechRadar/暂缓
+modified: 20260815033746265
+tags: TechRadar/暂缓 $:/NowledgeMem
 title: ollama
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/playwright mcp.tid
+++ b/tiddlers/playwright mcp.tid
@@ -1,6 +1,6 @@
 created: 20250707025334592
-modified: 20250801085724950
-tags: 
+modified: 20260815033746265
+tags: $:/NowledgeMem
 title: playwright mcp
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/playwright timeout default 30s.tid
+++ b/tiddlers/playwright timeout default 30s.tid
@@ -1,6 +1,6 @@
 created: 20250730090141816
-modified: 20250730090156574
-tags: 
+modified: 20260815033746265
+tags: $:/NowledgeMem
 title: playwright timeout default 30s
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/pnpm install env.CI=true 不更新 lockfile.tid
+++ b/tiddlers/pnpm install env.CI=true 不更新 lockfile.tid
@@ -1,6 +1,6 @@
 created: 20250804055125980
-modified: 20250804055218370
-tags: 
+modified: 20260815033746265
+tags: $:/NowledgeMem
 title: pnpm install env.CI=true 不更新 lockfile
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/pnpm.tid
+++ b/tiddlers/pnpm.tid
@@ -1,6 +1,6 @@
 created: 20250923072507051
-modified: 20250923072726381
-tags: TechRadar/采纳
+modified: 20260815033746265
+tags: TechRadar/采纳 $:/NowledgeMem
 title: pnpm
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/postgres db docker volumne.tid
+++ b/tiddlers/postgres db docker volumne.tid
@@ -1,6 +1,6 @@
 created: 20250824181825742
-modified: 20250824182009922
-tags: 
+modified: 20260815033746265
+tags: $:/NowledgeMem
 title: postgres db docker volumne
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/prisma Optimistic concurrency control.tid
+++ b/tiddlers/prisma Optimistic concurrency control.tid
@@ -1,6 +1,6 @@
 created: 20250712074352031
-modified: 20250712074449041
-tags: 
+modified: 20260815033746266
+tags: $:/NowledgeMem
 title: prisma Optimistic concurrency control
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/prisma.tid
+++ b/tiddlers/prisma.tid
@@ -1,6 +1,6 @@
 created: 20250824181043453
-modified: 20250824181104416
-tags: 
+modified: 20260815033746266
+tags: $:/NowledgeMem
 title: prisma
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/qwik.tid
+++ b/tiddlers/qwik.tid
@@ -1,6 +1,6 @@
 created: 20241003023853447
-modified: 20250320044653678
-tags: TechRadar/评估 TechRadar/暂缓
+modified: 20260815033746266
+tags: TechRadar/评估 TechRadar/暂缓 $:/NowledgeMem
 title: qwik
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/rails ActiveSupport__MessageEncryptor__InvalidMessage.tid
+++ b/tiddlers/rails ActiveSupport__MessageEncryptor__InvalidMessage.tid
@@ -1,6 +1,6 @@
 created: 20250520083720456
-modified: 20250520083912067
-tags: error-logs
+modified: 20260815033746266
+tags: error-logs $:/NowledgeMem
 title: rails ActiveSupport::MessageEncryptor::InvalidMessage
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/rails puma foreman.tid
+++ b/tiddlers/rails puma foreman.tid
@@ -1,6 +1,6 @@
 created: 20250619085408161
-modified: 20250619085850467
-tags: 
+modified: 20260815033746266
+tags: $:/NowledgeMem
 title: rails puma foreman
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/rails routes 命名.tid
+++ b/tiddlers/rails routes 命名.tid
@@ -1,6 +1,6 @@
 created: 20250421082112680
-modified: 20250421082219882
-tags: 
+modified: 20260815033746266
+tags: $:/NowledgeMem
 title: rails routes 命名
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/react-charts.tid
+++ b/tiddlers/react-charts.tid
@@ -1,8 +1,8 @@
 created: 20210830061849817
 creator: TJ
-modified: 20250425083048600
+modified: 20260815033746267
 modifier: ThaddeusJiang
-tags: TechRadar/暂缓
+tags: TechRadar/暂缓 $:/NowledgeMem
 title: react-charts
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/react-hook-form ErrorMessage.tid
+++ b/tiddlers/react-hook-form ErrorMessage.tid
@@ -1,6 +1,6 @@
 created: 20250514071946327
-modified: 20250514072430618
-tags: 
+modified: 20260815033746267
+tags: $:/NowledgeMem
 title: react-hook-form ErrorMessage
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/react-hook-form deeply nested components.tid
+++ b/tiddlers/react-hook-form deeply nested components.tid
@@ -1,6 +1,6 @@
 created: 20250425095848319
-modified: 20251211094954751
-tags: tj-edu
+modified: 20260815033746267
+tags: tj-edu $:/NowledgeMem
 title: react-hook-form deeply nested components
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/react-hook-form useFormContext.tid
+++ b/tiddlers/react-hook-form useFormContext.tid
@@ -1,6 +1,6 @@
 created: 20250514072456197
-modified: 20250514072535756
-tags: 
+modified: 20260815033746267
+tags: $:/NowledgeMem
 title: react-hook-form useFormContext
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/react-hook-form.tid
+++ b/tiddlers/react-hook-form.tid
@@ -1,6 +1,6 @@
 created: 20250514072650036
-modified: 20250514072820291
-tags: 
+modified: 20260815033746267
+tags: $:/NowledgeMem
 title: react-hook-form
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/react-nl2br.tid
+++ b/tiddlers/react-nl2br.tid
@@ -1,6 +1,6 @@
 created: 20250430083110530
-modified: 20250430083507298
-tags: 
+modified: 20260815033746268
+tags: $:/NowledgeMem
 title: react-nl2br
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/react-query.tid
+++ b/tiddlers/react-query.tid
@@ -1,6 +1,6 @@
 created: 20250523063138039
-modified: 20250523063928145
-tags: TODO:
+modified: 20260815033746267
+tags: TODO: $:/NowledgeMem
 title: react-query
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/react-scan.tid
+++ b/tiddlers/react-scan.tid
@@ -1,6 +1,6 @@
 created: 20250514082042999
-modified: 20251211093340413
-tags: tj-stack
+modified: 20260815033746268
+tags: tj-stack $:/NowledgeMem
 title: react-scan
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/realtime Data.tid
+++ b/tiddlers/realtime Data.tid
@@ -1,6 +1,6 @@
 created: 20250825051809244
-modified: 20250825052000983
-tags: 
+modified: 20260815033746268
+tags: $:/NowledgeMem
 title: realtime Data
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/roboflow.tid
+++ b/tiddlers/roboflow.tid
@@ -1,6 +1,6 @@
 created: 20251211092046046
-modified: 20251211092227724
-tags: [[computer vision tools]] TechRadar/技术
+modified: 20260815033746269
+tags: [[computer vision tools]] TechRadar/技术 $:/NowledgeMem
 title: roboflow
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/ruby private.tid
+++ b/tiddlers/ruby private.tid
@@ -1,6 +1,6 @@
 created: 20250528054649271
-modified: 20250528054926751
-tags: 
+modified: 20260815033746268
+tags: $:/NowledgeMem
 title: ruby private
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/server-side client-side ENV 大不同.tid
+++ b/tiddlers/server-side client-side ENV 大不同.tid
@@ -1,6 +1,6 @@
 created: 20250808015842972
-modified: 20250808015956662
-tags: 
+modified: 20260815033746269
+tags: $:/NowledgeMem
 title: server-side client-side ENV 大不同
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/shadcn_ui Card.tid
+++ b/tiddlers/shadcn_ui Card.tid
@@ -1,6 +1,6 @@
 created: 20250824183121148
-modified: 20250824183513300
-tags: 
+modified: 20260815033746269
+tags: $:/NowledgeMem
 title: shadcn/ui Card
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/shadcn_ui spacing.tid
+++ b/tiddlers/shadcn_ui spacing.tid
@@ -1,6 +1,6 @@
 created: 20250824183548215
-modified: 20250824190911058
-tags: 
+modified: 20260815033746269
+tags: $:/NowledgeMem
 title: shadcn/ui spacing
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/sqlite 一点疑问.tid
+++ b/tiddlers/sqlite 一点疑问.tid
@@ -1,6 +1,6 @@
 created: 20250730055333813
-modified: 20250730060324573
-tags: 
+modified: 20260815033746269
+tags: $:/NowledgeMem
 title: sqlite 一点疑问
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/super-linter.tid
+++ b/tiddlers/super-linter.tid
@@ -1,6 +1,6 @@
 created: 20250514092256279
-modified: 20250514092405645
-tags: 
+modified: 20260815033746270
+tags: $:/NowledgeMem
 title: super-linter
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/svelte store.tid
+++ b/tiddlers/svelte store.tid
@@ -1,6 +1,6 @@
 created: 20250424094457717
-modified: 20250424095659120
-tags: 
+modified: 20260815033746270
+tags: $:/NowledgeMem
 title: svelte store
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/tech 失去恐惧症.tid
+++ b/tiddlers/tech 失去恐惧症.tid
@@ -1,6 +1,6 @@
 created: 20250703073302859
-modified: 20250708050525349
-tags: 
+modified: 20260815033746270
+tags: $:/NowledgeMem
 title: tech 失去恐惧症
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/tidewave.ai.tid
+++ b/tiddlers/tidewave.ai.tid
@@ -1,7 +1,7 @@
 created: 20250622032001969
 history: 2025-09-25
-modified: 20251114070459857
-tags: #repeated TechRadar/采纳
+modified: 20260815033746273
+tags: #repeated TechRadar/采纳 $:/NowledgeMem
 title: Tidewave.ai
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/tw5-lego_tag-renamer.tid
+++ b/tiddlers/tw5-lego_tag-renamer.tid
@@ -1,8 +1,8 @@
 created: 20230627095431301
-modified: 20251211094953621
+modified: 20260815033746274
 new: tj-edu
 old: TJ_edu
-tags: 
+tags: $:/NowledgeMem
 title: tw5-lego/tag-renamer
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/unstated.tid
+++ b/tiddlers/unstated.tid
@@ -1,6 +1,6 @@
 created: 20250318143354004
-modified: 20250425091141312
-tags: 
+modified: 20260815033746275
+tags: $:/NowledgeMem
 title: unstated
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/valibot.tid
+++ b/tiddlers/valibot.tid
@@ -1,6 +1,6 @@
 created: 20250926042248386
-modified: 20250926042331443
-tags: 
+modified: 20260815033746276
+tags: $:/NowledgeMem
 title: valibot
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/vim shortcuts - 进阶.tid
+++ b/tiddlers/vim shortcuts - 进阶.tid
@@ -1,6 +1,6 @@
 created: 20250609011944332
-modified: 20250609012042421
-tags: 
+modified: 20260815033746276
+tags: $:/NowledgeMem
 title: vim shortcuts - 进阶
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/vim 快捷键 - 基本.tid
+++ b/tiddlers/vim 快捷键 - 基本.tid
@@ -1,6 +1,6 @@
 created: 20250609011151074
-modified: 20250609011806024
-tags: 
+modified: 20260815033746276
+tags: $:/NowledgeMem
 title: vim 快捷键 - 基本
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/web frontend_ 正式项目 form helper 是必须的.tid
+++ b/tiddlers/web frontend_ 正式项目 form helper 是必须的.tid
@@ -1,6 +1,6 @@
 created: 20251001015335767
-modified: 20251211094954751
-tags: tj-edu
+modified: 20260815033746277
+tags: tj-edu $:/NowledgeMem
 title: web frontend: 正式项目 form helper 是必须的
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/web number input CSS.tid
+++ b/tiddlers/web number input CSS.tid
@@ -1,6 +1,6 @@
 created: 20251006014540818
-modified: 20251006015049942
-tags: 
+modified: 20260815033746277
+tags: $:/NowledgeMem
 title: web number input CSS
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/wretch.tid
+++ b/tiddlers/wretch.tid
@@ -1,6 +1,6 @@
 created: 20230325050235024
-modified: 20250425091324612
-tags: TechRadar/采纳
+modified: 20260815033746277
+tags: TechRadar/采纳 $:/NowledgeMem
 title: wretch
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/ws js.tid
+++ b/tiddlers/ws js.tid
@@ -1,6 +1,6 @@
 created: 20250425080649922
-modified: 20250425080941407
-tags: 
+modified: 20260815033746277
+tags: $:/NowledgeMem
 title: ws js
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/xstate.tid
+++ b/tiddlers/xstate.tid
@@ -1,6 +1,6 @@
 created: 20220622132816655
-modified: 20250920070926850
-tags: TechRadar/语言&框架
+modified: 20260815033746277
+tags: TechRadar/语言&框架 $:/NowledgeMem
 title: xstate
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/zod literal vs. enum.tid
+++ b/tiddlers/zod literal vs. enum.tid
@@ -1,6 +1,6 @@
 created: 20250609021804862
-modified: 20250609021925845
-tags: 
+modified: 20260815033746278
+tags: $:/NowledgeMem
 title: zod literal vs. enum
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/zod.tid
+++ b/tiddlers/zod.tid
@@ -1,6 +1,6 @@
 created: 20250923082354080
-modified: 20250923082502537
-tags: TechRadar/采纳
+modified: 20260815033746278
+tags: TechRadar/采纳 $:/NowledgeMem
 title: zod
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/zod_v4 支持生成 JSON Schema.tid
+++ b/tiddlers/zod_v4 支持生成 JSON Schema.tid
@@ -1,6 +1,6 @@
 created: 20250610093314474
-modified: 20250610093442166
-tags: 
+modified: 20260815033746278
+tags: $:/NowledgeMem
 title: zod/v4 支持生成 JSON Schema
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/不同语言的命名习惯之“参数列表”.tid
+++ b/tiddlers/不同语言的命名习惯之“参数列表”.tid
@@ -1,6 +1,6 @@
 created: 20250107060502876
-modified: 20250424101725140
-tags: 
+modified: 20260815033746278
+tags: $:/NowledgeMem
 title: 不同语言的命名习惯之“参数列表”
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/不建议：默认选择 SPA.tid
+++ b/tiddlers/不建议：默认选择 SPA.tid
@@ -1,5 +1,6 @@
 created: 20221107004431032
-modified: 20250425082718601
+modified: 20260815033746278
+tags: $:/NowledgeMem
 title: 不建议：默认选择 SPA
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/不要 export default.tid
+++ b/tiddlers/不要 export default.tid
@@ -1,6 +1,6 @@
 created: 20250424093356443
-modified: 20250923050823440
-tags: [[JS Rules]]
+modified: 20260815033746278
+tags: [[JS Rules]] $:/NowledgeMem
 title: 不要 export default
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/不要使用 SCSS 和 CSS-in-JS.tid
+++ b/tiddlers/不要使用 SCSS 和 CSS-in-JS.tid
@@ -1,6 +1,6 @@
 created: 20250424092953027
-modified: 20250424093050138
-tags: [[CSS rules]]
+modified: 20260815033746278
+tags: [[CSS rules]] $:/NowledgeMem
 title: 不要使用 SCSS 和 CSS-in-JS
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/不要编写嵌套 CSS.tid
+++ b/tiddlers/不要编写嵌套 CSS.tid
@@ -1,6 +1,6 @@
 created: 20250424091820420
-modified: 20250424092852149
-tags: [[CSS rules]]
+modified: 20260815033746278
+tags: [[CSS rules]] $:/NowledgeMem
 title: 不要编写嵌套 CSS
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/不要采用 BEM CSS.tid
+++ b/tiddlers/不要采用 BEM CSS.tid
@@ -1,6 +1,6 @@
 created: 20250424092903902
-modified: 20250424092930578
-tags: [[CSS rules]]
+modified: 20260815033746278
+tags: [[CSS rules]] $:/NowledgeMem
 title: 不要采用 BEM CSS
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/为什么不推荐使用 npm 安装 CLI？.tid
+++ b/tiddlers/为什么不推荐使用 npm 安装 CLI？.tid
@@ -1,6 +1,6 @@
 created: 20250903015412166
-modified: 20250903015759790
-tags: 
+modified: 20260815033746278
+tags: $:/NowledgeMem
 title: 为什么不推荐使用 npm 安装 CLI？
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/乐观锁.tid
+++ b/tiddlers/乐观锁.tid
@@ -1,5 +1,6 @@
 created: 20250801045611207
-modified: 20250801045641432
+modified: 20260815033746279
+tags: $:/NowledgeMem
 title: 乐观锁
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/什么是 SEO.tid
+++ b/tiddlers/什么是 SEO.tid
@@ -1,7 +1,8 @@
 created: 20210602062605424
 creator: TJ
-modified: 20210603134427475
+modified: 20260815033746279
 modifier: TJ
+tags: $:/NowledgeMem
 title: 什么是 SEO
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/使用一些容易输入的前缀可以提高效率.tid
+++ b/tiddlers/使用一些容易输入的前缀可以提高效率.tid
@@ -1,6 +1,6 @@
 created: 20250801085059290
-modified: 20250801085217056
-tags: 
+modified: 20260815033746279
+tags: $:/NowledgeMem
 title: 使用一些容易输入的前缀可以提高效率
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/依赖注入风格的问题.tid
+++ b/tiddlers/依赖注入风格的问题.tid
@@ -1,6 +1,6 @@
 created: 20250622033617039
-modified: 20250622034056785
-tags: 
+modified: 20260815033746279
+tags: $:/NowledgeMem
 title: 依赖注入风格的问题
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/停止使用硬编码多语言翻译.tid
+++ b/tiddlers/停止使用硬编码多语言翻译.tid
@@ -1,6 +1,6 @@
 created: 20250906035237398
-modified: 20251211095306615
-tags: TechRadar/放弃 2025 tj-edu
+modified: 20260814152325293
+tags: TechRadar/放弃 2025 tj-edu $:/NowledgeMem
 title: 停止使用硬编码多语言翻译
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/关于 CICD 的过度设计.tid
+++ b/tiddlers/关于 CICD 的过度设计.tid
@@ -1,6 +1,6 @@
 created: 20250730023528077
-modified: 20250730024414174
-tags: 
+modified: 20260815033746279
+tags: $:/NowledgeMem
 title: 关于 CICD 的过度设计
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/关于 DDD （Domain Driven Development）.tid
+++ b/tiddlers/关于 DDD （Domain Driven Development）.tid
@@ -1,6 +1,6 @@
 created: 20250616050536629
-modified: 20250616052649420
-tags: blog
+modified: 20260815033746279
+tags: blog $:/NowledgeMem
 title: 关于 DDD （Domain Driven Development）
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/其他链接.tid
+++ b/tiddlers/其他链接.tid
@@ -1,6 +1,6 @@
 created: 20250424102735842
-modified: 20250507042806879
-tags: 
+modified: 20260815033746279
+tags: $:/NowledgeMem
 title: 其他链接
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/再推荐 grep.app.tid
+++ b/tiddlers/再推荐 grep.app.tid
@@ -1,6 +1,6 @@
 created: 20250818042021132
-modified: 20251211093402782
-tags: tj-stack
+modified: 20260815033746279
+tags: tj-stack $:/NowledgeMem
 title: 再推荐 grep.app
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/准则.tid
+++ b/tiddlers/准则.tid
@@ -1,6 +1,6 @@
 created: 20250812084317240
-modified: 20250812084746723
-tags: 
+modified: 20260815033746279
+tags: $:/NowledgeMem
 title: 准则
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/刀耕火种.tid
+++ b/tiddlers/刀耕火种.tid
@@ -1,5 +1,6 @@
 created: 20251001015910333
-modified: 20251001020209956
+modified: 20260815033746280
+tags: $:/NowledgeMem
 title: 刀耕火种
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/别再好为人师.tid
+++ b/tiddlers/别再好为人师.tid
@@ -1,6 +1,6 @@
 created: 20250812084750778
-modified: 20250812085149792
-tags: [[This is a note to myself.]]
+modified: 20260815033746280
+tags: [[This is a note to myself.]] $:/NowledgeMem
 title: 别再好为人师
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/基于 URL 的状态管理.tid
+++ b/tiddlers/基于 URL 的状态管理.tid
@@ -1,6 +1,6 @@
 created: 20250318144644438
-modified: 20251211094954751
-tags: tj-edu
+modified: 20260815033746280
+tags: tj-edu $:/NowledgeMem
 title: 基于 URL 的状态管理
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/基于 version 的 db update.tid
+++ b/tiddlers/基于 version 的 db update.tid
@@ -1,6 +1,6 @@
 created: 20250712073901269
-modified: 20250712074255920
-tags: 
+modified: 20260815033746280
+tags: $:/NowledgeMem
 title: 基于 version 的 db update
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/声明式.tid
+++ b/tiddlers/声明式.tid
@@ -1,6 +1,6 @@
 created: 20250514072951333
-modified: 20250514093048455
-tags: 
+modified: 20260815033746280
+tags: $:/NowledgeMem
 title: 声明式
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/外部 library.tid
+++ b/tiddlers/外部 library.tid
@@ -1,6 +1,6 @@
 created: 20250708043921914
-modified: 20250708044803209
-tags: 
+modified: 20260815033746280
+tags: $:/NowledgeMem
 title: 外部 library
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/如何查看 docker image 内部文件系统？.tid
+++ b/tiddlers/如何查看 docker image 内部文件系统？.tid
@@ -1,6 +1,6 @@
 created: 20250520082356457
-modified: 20250520082439288
-tags: 
+modified: 20260815033746280
+tags: $:/NowledgeMem
 title: 如何查看 docker image 内部文件系统？
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/如何检查系统中 Node.js 的安装路径.tid
+++ b/tiddlers/如何检查系统中 Node.js 的安装路径.tid
@@ -1,6 +1,6 @@
 created: 20251204105104366
-modified: 20251204105104366
-tags:
+modified: 20260815033746280
+tags: $:/NowledgeMem
 title: 如何检查系统中 Node.js 的安装路径
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/如何检查系统中 global node_modules.tid
+++ b/tiddlers/如何检查系统中 global node_modules.tid
@@ -1,6 +1,6 @@
 created: 20251204120000000
-modified: 20251204120000000
-tags:
+modified: 20260815033746280
+tags: $:/NowledgeMem
 title: 如何检查系统中 global node_modules
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/如何清理 Volta (VOLTA_HOME).tid
+++ b/tiddlers/如何清理 Volta (VOLTA_HOME).tid
@@ -1,6 +1,6 @@
 created: 20251204110000000
-modified: 20251204110000000
-tags:
+modified: 20260815033746280
+tags: $:/NowledgeMem
 title: 如何清理 Volta (VOLTA_HOME)
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/如果不是被屎山代码折腾的没有状态了，我也不会摆烂使用 any.tid
+++ b/tiddlers/如果不是被屎山代码折腾的没有状态了，我也不会摆烂使用 any.tid
@@ -1,6 +1,6 @@
 created: 20250612063602147
-modified: 20250612065108789
-tags: blog
+modified: 20260815033746281
+tags: blog $:/NowledgeMem
 title: 如果不是被屎山代码折腾的没有状态了，我也不会摆烂使用 any
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/小团队不应该使用“计费复杂的” Services.tid
+++ b/tiddlers/小团队不应该使用“计费复杂的” Services.tid
@@ -1,6 +1,6 @@
 created: 20240723055029887
-modified: 20250923082312020
-tags: 
+modified: 20260815033746281
+tags: $:/NowledgeMem
 title: 小团队不应该使用“计费复杂的” Services
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/心智负担.tid
+++ b/tiddlers/心智负担.tid
@@ -1,6 +1,6 @@
 created: 20250424092514679
-modified: 20250424092835373
-tags: 
+modified: 20260815033746281
+tags: $:/NowledgeMem
 title: 心智负担
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/我写 JS 从来不写 class，我没有遇到不使用 class 不行的需求.tid
+++ b/tiddlers/我写 JS 从来不写 class，我没有遇到不使用 class 不行的需求.tid
@@ -1,6 +1,6 @@
 created: 20250825040236213
-modified: 20250825040454309
-tags: 
+modified: 20260815033746281
+tags: $:/NowledgeMem
 title: 我写 JS 从来不写 class，我没有遇到不使用 class 不行的需求
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/我心中的技术水平等级.tid
+++ b/tiddlers/我心中的技术水平等级.tid
@@ -1,6 +1,6 @@
 created: 20250424102141916
-modified: 20250424102619018
-tags: 
+modified: 20260815033746281
+tags: $:/NowledgeMem
 title: 我心中的技术水平等级
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/我期待 client-server 通信就像函数调用（functions call）一样简单.tid
+++ b/tiddlers/我期待 client-server 通信就像函数调用（functions call）一样简单.tid
@@ -1,6 +1,6 @@
 created: 20250425073356498
-modified: 20250425081134716
-tags: 
+modified: 20260815033746281
+tags: $:/NowledgeMem
 title: 我期待 client-server 通信就像函数调用（functions call）一样简单
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/拒绝咬文嚼字.tid
+++ b/tiddlers/拒绝咬文嚼字.tid
@@ -1,6 +1,6 @@
 created: 20250730024420251
-modified: 20250730024715488
-tags: 
+modified: 20260815033746281
+tags: $:/NowledgeMem
 title: 拒绝咬文嚼字
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/拒绝被工具锁定.tid
+++ b/tiddlers/拒绝被工具锁定.tid
@@ -1,6 +1,6 @@
 created: 20250923082552812
-modified: 20250923082819651
-tags: 
+modified: 20260815033746281
+tags: $:/NowledgeMem
 title: 拒绝被工具锁定
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/敏捷开发.tid
+++ b/tiddlers/敏捷开发.tid
@@ -1,6 +1,6 @@
 created: 20250403202331553
-modified: 20250403202438807
-tags: 
+modified: 20260815033746281
+tags: $:/NowledgeMem
 title: 敏捷开发
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/是否要尝试 Cursor Dev Containers.tid
+++ b/tiddlers/是否要尝试 Cursor Dev Containers.tid
@@ -1,6 +1,6 @@
 created: 20250826021558792
-modified: 20250826022211476
-tags: 
+modified: 20260815033746282
+tags: $:/NowledgeMem
 title: 是否要尝试 Cursor Dev Containers
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/环境管理 dev test stag prod mask.tid
+++ b/tiddlers/环境管理 dev test stag prod mask.tid
@@ -1,6 +1,6 @@
 created: 20250521021611897
-modified: 20250801061904150
-tags: 
+modified: 20260815033746282
+tags: $:/NowledgeMem
 title: 环境管理 dev test stag prod mask
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/等待 React 的 jQuery 时刻.tid
+++ b/tiddlers/等待 React 的 jQuery 时刻.tid
@@ -1,5 +1,6 @@
 created: 20250501015113570
-modified: 20250501015324863
+modified: 20260815033746282
+tags: $:/NowledgeMem
 title: 等待 React 的 jQuery 时刻
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/简单性是一种优点.tid
+++ b/tiddlers/简单性是一种优点.tid
@@ -1,6 +1,6 @@
 created: 20240809054758701
-modified: 20240809055504009
-tags: 
+modified: 20260815033746282
+tags: $:/NowledgeMem
 title: 简单性是一种优点
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/类型体操.tid
+++ b/tiddlers/类型体操.tid
@@ -1,5 +1,6 @@
 created: 20250324135333081
-modified: 20250324135645696
+modified: 20260815033746282
+tags: $:/NowledgeMem
 title: 类型体操
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/纠结-到底应该如何管理自己文字.tid
+++ b/tiddlers/纠结-到底应该如何管理自己文字.tid
@@ -1,6 +1,6 @@
 created: 20250923024545899
-modified: 20250923024754375
-tags: 
+modified: 20260815033746282
+tags: $:/NowledgeMem
 title: 纠结-到底应该如何管理自己文字
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/草稿：我分析了 Browser History.tid
+++ b/tiddlers/草稿：我分析了 Browser History.tid
@@ -1,6 +1,6 @@
 created: 20250902104315879
-modified: 20250902104905878
-tags: Done
+modified: 20260815033746282
+tags: Done $:/NowledgeMem
 title: 草稿：我分析了 Browser History
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/软件领域的项目管理.tid
+++ b/tiddlers/软件领域的项目管理.tid
@@ -1,6 +1,6 @@
 created: 20250605100344899
-modified: 20250605100827232
-tags: 
+modified: 20260815033746282
+tags: $:/NowledgeMem
 title: 软件领域的项目管理
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/过早优化.tid
+++ b/tiddlers/过早优化.tid
@@ -1,5 +1,6 @@
 created: 20251017013736821
-modified: 20251017013829087
+modified: 20260815033746283
+tags: $:/NowledgeMem
 title: 过早优化
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/露营地规则（Compsite Rule）.tid
+++ b/tiddlers/露营地规则（Compsite Rule）.tid
@@ -1,7 +1,7 @@
 created: 20230109020226458
 history: 2025-09-23
-modified: 20251114070459857
-tags: #repeated
+modified: 20260815033746283
+tags: #repeated $:/NowledgeMem
 title: 露营地规则（Compsite Rule）
 type: text/vnd.tiddlywiki
 wikipedia: https://en.wikipedia.org/wiki/Leaving_the_world_a_better_place

--- a/tiddlers/非社交类应用.tid
+++ b/tiddlers/非社交类应用.tid
@@ -1,6 +1,6 @@
 created: 20250812085218641
-modified: 20250812085930010
-tags: 
+modified: 20260815033746283
+tags: $:/NowledgeMem
 title: 非社交类应用
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/🐛 常见错误：GitHub Actions on 中使用 paths 作为过滤条件.tid
+++ b/tiddlers/🐛 常见错误：GitHub Actions on 中使用 paths 作为过滤条件.tid
@@ -1,6 +1,6 @@
 created: 20250514063405458
-modified: 20250730043006288
-tags: 
+modified: 20260815033746283
+tags: $:/NowledgeMem
 title: 🐛 常见错误：GitHub Actions on 中使用 paths 作为过滤条件
 type: text/vnd.tiddlywiki
 

--- a/tiddlers/🚨lint-staged のよくある間違い.tid
+++ b/tiddlers/🚨lint-staged のよくある間違い.tid
@@ -1,6 +1,6 @@
 created: 20250730030814462
-modified: 20250730033113443
-tags: 
+modified: 20260815033746283
+tags: $:/NowledgeMem
 title: 🚨lint-staged のよくある間違い
 type: text/vnd.tiddlywiki
 


### PR DESCRIPTION
## 结果

- 新导入 344 条，成功标记 344 条，失败 0 条。
- 原有标记 13 条，当前共 357 条。
- 本 PR 提交 356 个已由 `origin/main` 跟踪的 tiddler。
- 只修改 `modified` 和 `tags`，正文无变化。
- TiddlyWiki 构建和 diff 检查均通过。

当前 checkout 有 1 个 tiddler 只存在于无关的本地提交。为避免混入无关内容，本 PR 不包含该文件。

## 原因

源 tiddler 必须保存 `$:/NowledgeMem` 标记。否则其他 checkout 可能重复导入相同内容。

## 命令与执行结果

逐 tiddler 明细按要求省略。以下保留完整汇总。

### 1. 准备环境

```bash
mise trust && mise install
npm view tiddlynmem version
```

```text
mise all tools are installed
0.1.0
```

### 2. 首次生成计划

```bash
npx --yes tiddlynmem@0.1.0 plan
```

```text
Scanned: 482
Ready: 344
Skipped: 131 (empty: 59, imported: 13, sensitive: 4, system: 43, unsupported_type: 12)
Imported: 0
Tagged: 0
Failed: 7
Warnings: 13
Exit code: 1
Saved plan: none
```

7 个 UI helper 渲染后的 Markdown 为空。它们不是知识内容，因此从导入计划中排除。

### 3. 生成有效计划

执行脚本通过 `trap` 保证 7 个 UI helper 在成功或失败后都原样恢复。文件名按要求省略。

```bash
hold_dir=.tiddlynmem/import-excluded-empty-render
mkdir -p "$hold_dir"

restore_files() {
  for file in "${ui_helper_tiddlers[@]}"; do
    mv "$hold_dir/${file#tiddlers/}" "$file"
  done
}
trap restore_files EXIT

for file in "${ui_helper_tiddlers[@]}"; do
  mv "$file" "$hold_dir/${file#tiddlers/}"
done

npx --yes tiddlynmem@0.1.0 plan > .tiddlynmem/full-plan.log
grep -q '^Failed: 0$' .tiddlynmem/full-plan.log
test "$(jq '.memories | length' .tiddlynmem/plan.json)" -eq 344
```

```text
Scanned: 475
Ready: 344
Skipped: 131 (empty: 59, imported: 13, sensitive: 4, system: 43, unsupported_type: 12)
Imported: 0
Tagged: 0
Failed: 0
Warnings: 13
Saved plan: .tiddlynmem/plan.json
packageVersion: 0.1.0
memoryCount: 344
spaceId: default
wikiId: public-DevNote-4d2b30658a82
```

### 4. 应用计划

```bash
npx --yes tiddlynmem@0.1.0 apply > .tiddlynmem/full-apply.log
```

```text
Scanned: 475
Ready: 344
Skipped: 131 (empty: 59, imported: 13, sensitive: 4, system: 43, unsupported_type: 12)
Imported: 344
Tagged: 344
Failed: 0
Warnings: 13
```

计划执行后已删除。7 个 UI helper 已恢复。

### 5. 创建独立提交

本地 `main` 有无关改动，因此从 `origin/main` 创建独立 worktree，只同步导入字段。

```bash
git fetch origin main
git worktree add \
  -b chore/import-tiddlywiki-nowledge-mem \
  "$HOME/git/worktree/public-DevNote/chore/import-tiddlywiki-nowledge-mem" \
  origin/main

git diff --check
rm -rf output
tiddlywiki --build index

git add tiddlers
git diff --cached --check
git cz --non-interactive --disable-emoji \
  --type chore \
  --subject "mark imported TiddlyWiki memories"
```

```text
source markers: 357
updated target tiddlers: 356
source-only tiddlers skipped: 1
modified files: 356
non-import-header diff lines: 0
git diff --check: passed
TiddlyWiki build: passed
git diff --cached --check: passed
commit: 8b211a1 chore: mark imported TiddlyWiki memories
```

## 验证

```bash
rg -l '^tags:.*\$:/NowledgeMem' tiddlers | wc -l
test ! -e .tiddlynmem/plan.json
git diff --check
nmem --json m show 01380de9-e664-5b67-962d-801aacc33482
```

```text
marker files: 357
saved plan: removed
restored UI helper files: 7
body diff lines: 0
Nowledge Mem lookup: found
```

## 风险

- 13 个图片警告：嵌入图片数据按工具设计省略。
- 4 个敏感标题：未启用 `--include-sensitive`，因此未导入。
- 7 个 UI helper：不是知识内容，因此未导入。
- 仓库没有 UI snapshot 配置，因此未执行 snapshot update。

## 关联事项

无。
